### PR TITLE
Adapt Tasks to textual id

### DIFF
--- a/binding/python/generate.py
+++ b/binding/python/generate.py
@@ -84,7 +84,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # PositionTask
   posTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Vector3d&', 'pos'),
                            param('const Eigen::Vector3d&', 'bodyPoint',
                                  default_value='Eigen::Vector3d::Zero()')])
@@ -97,10 +97,10 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # OrientationTask
   oriTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Quaterniond&', 'ori')])
   oriTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Matrix3d&', 'ori')])
 
   oriTask.add_method('orientation', None, [param('const Eigen::Matrix3d&', 'ori')])
@@ -110,11 +110,11 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # SurfaceOrientationTask
   surfOriTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                               param('int', 'bodyId'),
+                               param('const std::string&', 'bodyName'),
                                param('const Eigen::Quaterniond&', 'ori'),
                                param('const sva::PTransformd&', 'X_b_s')])
   surfOriTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                               param('int', 'bodyId'),
+                               param('const std::string&', 'bodyName'),
                                param('const Eigen::Matrix3d&', 'ori'),
                                param('const sva::PTransformd&', 'X_b_s')])
 
@@ -125,14 +125,14 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # GazeTask
   gazeTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                            param('int', 'bodyId'),
+                            param('const std::string&', 'bodyName'),
                             param('const Eigen::Vector2d&', 'point2d'),
                             param('double', 'depthEstimate'),
                             param('const sva::PTransformd&', 'X_b_gaze'),
                             param('const Eigen::Vector2d&', 'point2d_ref',
                                   default_value='Eigen::Vector2d::Zero()')])
   gazeTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                            param('int', 'bodyId'),
+                            param('const std::string&', 'bodyName'),
                             param('const Eigen::Vector3d&', 'point3d'),
                             param('const sva::PTransformd&', 'X_b_gaze'),
                             param('const Eigen::Vector2d&', 'point2d_ref',
@@ -155,7 +155,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # Position Based Visual Servoing Task
   pbvsTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                            param('int', 'bodyId'),
+                            param('const std::string&', 'bodyName'),
                             param('const sva::PTransformd&', 'X_t_s'),
                             param('const sva::PTransformd&', 'X_b_s',
                             default_value='sva::PTransformd::Identity()')])
@@ -225,7 +225,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
   multiRobotTransformTask.add_constructor(
     [param('const std::vector<rbd::MultiBody>&', 'mbs'),
      param('int', 'r1Index'), param('int', 'r2Index'),
-     param('int', 'r1BodyIndex'), param('int', 'r2BodyIndex'),
+     param('const std::string&', 'r1BodyName'), param('const std::string&', 'r2BodyName'),
      param('const sva::PTransformd&', 'X_r1b_r1s'),
      param('const sva::PTransformd&', 'X_r2b_r2s')])
 
@@ -264,7 +264,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # LinVelocityTask
   linVelTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Vector3d&', 'pos'),
                            param('const Eigen::Vector3d&', 'bodyPoint',
                                  default_value='Eigen::Vector3d::Zero()')])
@@ -277,10 +277,10 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # OrientationTrackingTask
   oriTrackTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                                param('int', 'bodyId'),
+                                param('const std::string&', 'bodyName'),
                                 param('const Eigen::Vector3d&', 'bodyPoint'),
                                 param('const Eigen::Vector3d&', 'bodyAxis'),
-                                param('const std::vector<int>&', 'trackingJointId'),
+                                param('const std::vector<std::string>&', 'trackingJointName'),
                                 param('const Eigen::Vector3d&', 'trackedPoint')])
 
   oriTrackTask.add_method('trackedPoint', None, [param('const Eigen::Vector3d&', 'bPoint')])
@@ -311,7 +311,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
     cls.add_method('jac', retval('const Eigen::MatrixXd&'), [], is_const=True)
 
   transTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                             param('int', 'bodyId'),
+                             param('const std::string&', 'bodyName'),
                              param('const sva::PTransformd&', 'X_0_t'),
                              param('const sva::PTransformd&', 'X_b_p',
                                    default_value='sva::PTransformd::Identity()'),
@@ -324,7 +324,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # SurfaceTransformTask
   surfTransTask.add_constructor([param('const rbd::MultiBody&', 'mb'),
-                                 param('int', 'bodyId'),
+                                 param('const std::string&', 'bodyName'),
                                  param('const sva::PTransformd&', 'X_0_t'),
                                  param('const sva::PTransformd&', 'X_b_p',
                                        default_value='sva::PTransformd::Identity()')])
@@ -334,7 +334,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
   # RelativeDistTask
   rbInfo = relDistTask.add_class('rbInfo')
   rbInfo.add_constructor([])
-  rbInfo.add_constructor([param('int', 'bodyId'), param('Eigen::Vector3d', 'r_b1_p'),
+  rbInfo.add_constructor([param('const std::string&', 'bodyName'), param('Eigen::Vector3d', 'r_b1_p'),
                           param('Eigen::Vector3d', 'r_0_b2p')])
   relDistTask.add_constructor([param('const rbd::MultiBody&', 'mb'), param('double', 'timestep'),
                                param('rbInfo&', 'rbi1'), param('rbInfo&', 'rbi2'),
@@ -350,7 +350,7 @@ def build_tasks(posTask, oriTask, surfOriTask, gazeTask, pbvsTask, positionTask,
 
   # VectorOrientationTask
   vectOriTask.add_constructor([param('const rbd::MultiBody', 'mb'),
-                               param('int', 'bodyId'),
+                               param('const std::string&', 'bodyName'),
                                param('const Eigen::Vector3d&', 'bodyVector'),
                                param('const Eigen::Vector3d&', 'targetVector')])
   vectOriTask.add_method('update', None,
@@ -595,12 +595,13 @@ def build_qp(tasks):
   # ContactId
   contactId.add_constructor([])
   contactId.add_constructor([param('int', 'r1Index'), param('int', 'r2Index'),
-                             param('int', 'r1BodyId'), param('int', 'r2BodyId'),
+                             param('const std::string&', 'r1BodyName'),
+                             param('const std::string&', 'r2BodyName'),
                              param('int', 'nSurf', default_value='-1')])
   contactId.add_instance_attribute('r1Index', 'int')
   contactId.add_instance_attribute('r2Index', 'int')
-  contactId.add_instance_attribute('r1BodyId', 'int')
-  contactId.add_instance_attribute('r2BodyId', 'int')
+  contactId.add_instance_attribute('r1BodyName', 'std::string')
+  contactId.add_instance_attribute('r2BodyName', 'std::string')
   contactId.add_instance_attribute('ambiguityId', 'int')
   contactId.add_binary_comparison_operator('==')
   contactId.add_binary_comparison_operator('!=')
@@ -610,7 +611,8 @@ def build_qp(tasks):
   unilateralContact.add_constructor([])
   unilateralContact.add_constructor([
     param('int', 'r1Index'), param('int', 'r2Index'),
-    param('int', 'r1BodyId'), param('int', 'r2BodyId'),
+    param('const std::string&', 'r1BodyName'),
+    param('const std::string&', 'r2BodyName'),
     param('const std::vector<Eigen::Vector3d>&', 'r1Points'),
     param('const Eigen::Matrix3d&', 'r1Frame'),
     param('const sva::PTransformd&', 'X_b1_b2'),
@@ -619,7 +621,8 @@ def build_qp(tasks):
            default_value='sva::PTransformd::Identity()')])
   unilateralContact.add_constructor([
     param('int', 'r1Index'), param('int', 'r2Index'),
-    param('int', 'r1BodyId'), param('int', 'r2BodyId'),
+    param('const std::string&', 'r1BodyName'),
+    param('const std::string&', 'r2BodyName'),
     param('int', 'ambiguityId'),
     param('const std::vector<Eigen::Vector3d>&', 'r1Points'),
     param('const Eigen::Matrix3d&', 'r1Frame'),
@@ -665,7 +668,8 @@ def build_qp(tasks):
   bilateralContact.add_constructor([])
   bilateralContact.add_constructor([
     param('int', 'r1Index'), param('int', 'r2Index'),
-    param('int', 'r1BodyId'), param('int', 'r2BodyId'),
+    param('const std::string&', 'r1BodyName'),
+    param('const std::string&', 'r2BodyName'),
     param('const std::vector<Eigen::Vector3d>&', 'r1Points'),
     param('const std::vector<Eigen::Matrix3d>&', 'r1Frames'),
     param('const sva::PTransformd&', 'X_b1_b2'),
@@ -674,7 +678,8 @@ def build_qp(tasks):
            default_value='sva::PTransformd::Identity()')])
   bilateralContact.add_constructor([
     param('int', 'r1Index'), param('int', 'r2Index'),
-    param('int', 'r1BodyId'), param('int', 'r2BodyId'),
+    param('const std::string&', 'r1BodyName'),
+    param('const std::string&', 'r2BodyName'),
     param('int', 'ambiguityId'),
     param('const std::vector<Eigen::Vector3d>&', 'r1Points'),
     param('const std::vector<Eigen::Matrix3d>&', 'r1Frames'),
@@ -721,28 +726,28 @@ def build_qp(tasks):
 
   # JointStiffness
   jointStiffness.add_constructor([])
-  jointStiffness.add_constructor([param('int', 'jointId'),
+  jointStiffness.add_constructor([param('const std::string&', 'jointName'),
                                   param('double', 'stiffness')])
-  jointStiffness.add_instance_attribute('jointId', 'int')
+  jointStiffness.add_instance_attribute('jointName', 'std::string')
   jointStiffness.add_instance_attribute('stiffness', 'double')
 
   # JointGains
   jointGains.add_constructor([])
-  jointGains.add_constructor([param('int', 'jointId'),
+  jointGains.add_constructor([param('const std::string&', 'jointName'),
                               param('double', 'stiffness')])
-  jointGains.add_constructor([param('int', 'jointId'),
+  jointGains.add_constructor([param('const std::string&', 'jointName'),
                               param('double', 'stiffness'),
                               param('double', 'damping')])
-  jointGains.add_instance_attribute('jointId', 'int')
+  jointGains.add_instance_attribute('jointName', 'std::string')
   jointGains.add_instance_attribute('stiffness', 'double')
   jointGains.add_instance_attribute('damping', 'double')
 
   # SpringJoint
   springJoint.add_constructor([])
-  springJoint.add_constructor([param('int', 'jointId'),
+  springJoint.add_constructor([param('const std::string&', 'jointName'),
                                param('double', 'K'), param('double', 'C'),
                                param('double', 'O')])
-  springJoint.add_instance_attribute('jointId', 'int')
+  springJoint.add_instance_attribute('jointName', 'std::string')
   springJoint.add_instance_attribute('K', 'double')
   springJoint.add_instance_attribute('C', 'double')
   springJoint.add_instance_attribute('O', 'double')
@@ -1031,7 +1036,7 @@ def build_qp(tasks):
   # PositionTask
   posTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                            param('int', 'robotIndex'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Vector3d&', 'pos'),
                            param('const Eigen::Vector3d&', 'bodyPoint',
                                  default_value='Eigen::Vector3d::Zero()')])
@@ -1045,11 +1050,11 @@ def build_qp(tasks):
   # OrientationTask
   oriTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                            param('int', 'robotIndex'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Quaterniond&', 'ori')])
   oriTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                            param('int', 'robotIndex'),
-                           param('int', 'bodyId'),
+                           param('const std::string&', 'bodyName'),
                            param('const Eigen::Matrix3d&', 'ori')])
 
   oriTask.add_method('orientation', None, [param('const Eigen::Matrix3d&', 'ori')])
@@ -1064,7 +1069,7 @@ def build_qp(tasks):
     cls.add_method('X_b_p', retval('sva::PTransformd'), [], is_const=True)
   transTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                              param('int', 'robotIndex'),
-                             param('int', 'bodyId'),
+                             param('const std::string&', 'bodyName'),
                              param('const sva::PTransformd&', 'X_0_t'),
                              param('const sva::PTransformd&', 'X_b_p',
                                    default_value='sva::PTransformd::Identity()'),
@@ -1078,7 +1083,7 @@ def build_qp(tasks):
   # SurfaceTransformTask
   surfTransTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                                  param('int', 'robotIndex'),
-                                 param('int', 'bodyId'),
+                                 param('const std::string&', 'bodyName'),
                                  param('const sva::PTransformd&', 'X_0_t'),
                                  param('const sva::PTransformd&', 'X_b_p',
                                        default_value='sva::PTransformd::Identity()')])
@@ -1088,12 +1093,12 @@ def build_qp(tasks):
   # SurfaceOrientationTask
   surfOriTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                                param('int', 'robotIndex'),
-                               param('int', 'bodyId'),
+                               param('const std::string&', 'bodyName'),
                                param('const Eigen::Quaterniond&', 'ori'),
                                param('const sva::PTransformd&', 'X_b_s')])
   surfOriTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                                param('int', 'robotIndex'),
-                               param('int', 'bodyId'),
+                               param('const std::string&', 'bodyName'),
                                param('const Eigen::Matrix3d&', 'ori'),
                                param('const sva::PTransformd&', 'X_b_s')])
 
@@ -1104,7 +1109,7 @@ def build_qp(tasks):
   # GazeTask
   gazeTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                             param('int', 'robotIndex'),
-                            param('int', 'bodyId'),
+                            param('const std::string&', 'bodyName'),
                             param('const Eigen::Vector2d&', 'point2d'),
                             param('double', 'depthEstimate'),
                             param('const sva::PTransformd&', 'X_b_gaze'),
@@ -1112,7 +1117,7 @@ def build_qp(tasks):
                                   default_value='Eigen::Vector2d::Zero()')])
   gazeTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                             param('int', 'robotIndex'),
-                            param('int', 'bodyId'),
+                            param('const std::string&', 'bodyName'),
                             param('const Eigen::Vector3d&', 'point3d'),
                             param('const sva::PTransformd&', 'X_b_gaze'),
                             param('const Eigen::Vector2d&', 'point2d_ref',
@@ -1128,7 +1133,7 @@ def build_qp(tasks):
   # PositionBasedVisServoTask
   pbvsTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                             param('int', 'robotIndex'),
-                            param('int', 'bodyId'),
+                            param('const std::string&', 'bodyName'),
                             param('const sva::PTransformd&', 'X_t_s'),
                             param('const sva::PTransformd&', 'X_b_s',
                             default_value='sva::PTransformd::Identity()')])
@@ -1185,7 +1190,7 @@ def build_qp(tasks):
   torqueTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                                param('int', 'robotIndex'),
                                param('const TorqueBound&', 'tb'),
-                               param('int', 'efId'),
+                               param('const std::string&', 'efName'),
                                param('double', 'weight')])
 
   torqueTask.add_method('update', None,
@@ -1249,7 +1254,8 @@ def build_qp(tasks):
   multiRobotTransformTask.add_constructor(
       [param('const std::vector<rbd::MultiBody>&', 'mbs'),
       param('int', 'r1Index'), param('int', 'r2Index'),
-      param('int', 'r1BodyIndex'), param('int', 'r2BodyIndex'),
+      param('const std::string&', 'r1BodyName'),
+      param('const std::string&', 'r2BodyName'),
       param('const sva::PTransformd&', 'X_r1b_r1s'),
       param('const sva::PTransformd&', 'X_r2b_r2s'),
       param('double', 'stiffness'), param('double', 'weight')])
@@ -1306,7 +1312,7 @@ def build_qp(tasks):
   # LinVelocityTask
   linVelTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                               param('int', 'robotIndex'),
-                              param('int', 'bodyId'),
+                              param('const std::string&', 'bodyName'),
                               param('const Eigen::Vector3d&', 'pos'),
                               param('const Eigen::Vector3d&', 'bodyPoint',
                                     default_value='Eigen::Vector3d::Zero()')])
@@ -1320,10 +1326,10 @@ def build_qp(tasks):
   # OrientationTrackingTask
   oriTrackTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
                                 param('int', 'robotIndex'),
-                                param('int', 'bodyId'),
+                                param('const std::string&', 'bodyName'),
                                 param('const Eigen::Vector3d&', 'bodyPoint'),
                                 param('const Eigen::Vector3d&', 'bodyAxis'),
-                                param('const std::vector<int>&', 'trackingJointId'),
+                                param('const std::vector<std::string>&', 'trackingJointName'),
                                 param('const Eigen::Vector3d&', 'trackedPoint')])
 
   oriTrackTask.add_method('trackedPoint', None, [param('const Eigen::Vector3d&', 'bPoint')])
@@ -1338,20 +1344,20 @@ def build_qp(tasks):
                                   param('int', 'robotIndex'),
                                   param('tasks::qp::HighLevelTask*', 'hl',
                                         transfer_ownership=False),
-                                  param('const std::vector<int>&', 'selectedJointsId')])
+                                  param('const std::vector<std::string>&', 'selectedJointsName')])
   jointsSelector.add_method('ActiveJoints', retval('tasks::qp::JointsSelector'),
                             [param('const std::vector<rbd::MultiBody>&', 'mbs'),
                              param('int', 'robotIndex'),
                              param('tasks::qp::HighLevelTask*', 'hl',
                                    transfer_ownership=False),
-                             param('const std::vector<int>&', 'activeJointsId')],
+                             param('const std::vector<std::string>&', 'activeJointsName')],
                             is_static=True)
   jointsSelector.add_method('UnactiveJoints', retval('tasks::qp::JointsSelector'),
                             [param('const std::vector<rbd::MultiBody>&', 'mbs'),
                              param('int', 'robotIndex'),
                              param('tasks::qp::HighLevelTask*', 'hl',
                                    transfer_ownership=False),
-                             param('const std::vector<int>&', 'unactiveJointsId')],
+                             param('const std::vector<std::string>&', 'unactiveJointsName')],
                             is_static=True)
 
   # RelativeDistTask
@@ -1363,20 +1369,20 @@ def build_qp(tasks):
                                param('const Eigen::Vector3d&', 'u2', default_value='Eigen::Vector3d::Zero()')])
   relDistTask.add_method('robotPoint', None,
                          [param('const rbd::MultiBody&', 'mbs'),
-                          param('const int', 'bId'),
+                          param('const std::string&', 'bName'),
                           param('const Eigen::Vector3d&', 'point')])
   relDistTask.add_method('envPoint', None,
                          [param('const rbd::MultiBody&', 'mbs'),
-                          param('const int', 'bId'),
+                          param('const std::string&', 'bName'),
                           param('const Eigen::Vector3d&', 'point')])
   relDistTask.add_method('vector', None,
                          [param('const rbd::MultiBody&', 'mbs'),
-                          param('const int', 'bId'),
+                          param('const std::string&', 'bName'),
                           param('const Eigen::Vector3d&', 'u')])
 
   # VectorOrientationTask
   vectOriTask.add_constructor([param('const std::vector<rbd::MultiBody>&', 'mbs'),
-                               param('int', 'robotIndex'), param('int', 'bodyId'),
+                               param('int', 'robotIndex'), param('const std::string&', 'bodyName'),
                                param('const Eigen::Vector3d&', 'bodyVector'),
                                param('const Eigen::Vector3d&', 'targetVector')])
   vectOriTask.add_method('bodyVector', None, [param('const Eigen::Vector3d&', 'vector')])
@@ -1448,10 +1454,12 @@ def build_qp(tasks):
   collisionConstr.add_method('addCollision', None,
                              [param('const std::vector<rbd::MultiBody>&', 'mbs'),
                              param('int', 'collId'),
-                             param('int', 'r1Index'), param('int', 'r1BodyId'),
+                             param('int', 'r1Index'),
+                             param('const std::string&', 'r1BodyName'),
                              param('sch::S_Object*', 'body1', transfer_ownership=False),
                              param('const sva::PTransformd&', 'X_op1_o1'),
-                             param('int', 'r2Index'), param('int', 'r2BodyId'),
+                             param('int', 'r2Index'),
+                             param('const std::string&', 'r2BodyName'),
                              param('sch::S_Object*', 'body2', transfer_ownership=False),
                              param('const sva::PTransformd&', 'X_op2_o2'),
                              param('double', 'di'),
@@ -1533,19 +1541,19 @@ def build_qp(tasks):
                                       param('double', 'timeStep')])
   boundedSpeedConstr.add_method('addBoundedSpeed', None,
                                 [param('const std::vector<rbd::MultiBody>&', 'mbs'),
-                                 param('int', 'bodyId'),
+                                 param('const std::string&', 'bodyName'),
                                  param('const Eigen::Vector3d&', 'bodyPoint'),
                                  param('const Eigen::MatrixXd&', 'dof'),
                                  param('const Eigen::VectorXd&', 'speed')])
   boundedSpeedConstr.add_method('addBoundedSpeed', None,
                                 [param('const std::vector<rbd::MultiBody>&', 'mbs'),
-                                 param('int', 'bodyId'),
+                                 param('const std::string&', 'bodyName'),
                                  param('const Eigen::Vector3d&', 'bodyPoint'),
                                  param('const Eigen::MatrixXd&', 'dof'),
                                  param('const Eigen::VectorXd&', 'lowerSpeed'),
                                  param('const Eigen::VectorXd&', 'upperSpeed')])
   boundedSpeedConstr.add_method('removeBoundedSpeed', retval('bool'),
-                                [param('int', 'bodyId')])
+                                [param('const std::string&', 'bodyName')])
   boundedSpeedConstr.add_method('resetBoundedSpeeds', None, [])
   boundedSpeedConstr.add_method('nrBoundedSpeeds', retval('int'), [])
 
@@ -1615,6 +1623,7 @@ if __name__ == '__main__':
 
   # build list type
   tasks.add_container('std::vector<int>', 'int', 'vector')
+  tasks.add_container('std::vector<std::string>', 'std::string', 'vector')
   tasks.add_container('std::vector<double>', 'double', 'vector')
   tasks.add_container('std::vector<std::vector<double> >', 'std::vector<double>', 'vector')
   tasks.add_container('std::vector<rbd::MultiBody>',

--- a/src/QPConstr.h
+++ b/src/QPConstr.h
@@ -250,9 +250,9 @@ public:
 		* @param dampingOff \f$ \xi_{\text{off}} \f$.
 		*/
 	void addCollision(const std::vector<rbd::MultiBody>& mbs, int collId,
-		int r1Index, int r1BodyId,
+		int r1Index, const std::string& r1BodyName,
 		sch::S_Object* body1, const sva::PTransformd& X_op1_o1,
-		int r2Index, int r2BodyId,
+		int r2Index, const std::string& r2BodyName,
 		sch::S_Object* body2, const sva::PTransformd& X_op2_o2,
 		double di, double ds, double damping, double dampingOff=0.);
 
@@ -295,13 +295,14 @@ private:
 	struct BodyCollData
 	{
 		BodyCollData(const rbd::MultiBody& mb,
-			int rIndex, int bodyId, sch::S_Object* hull,
-			const sva::PTransformd& X_op_o);
+			int rIndex, const std::string& bodyName,
+			sch::S_Object* hull, const sva::PTransformd& X_op_o);
 
 		sch::S_Object* hull;
 		rbd::Jacobian jac;
 		sva::PTransformd X_op_o;
-		int rIndex, bIndex, bodyId;
+		int rIndex, bIndex;
+		std::string bodyName;
 	};
 
 	struct CollData
@@ -547,7 +548,8 @@ public:
 		* \f$ \underline{v} \in \mathbb{R}^{n} \f$ and
 		* \f$ \overline{v} \in \mathbb{R}^{n} \f$.
 		*/
-	void addBoundedSpeed(const std::vector<rbd::MultiBody>& mbs, int bodyId,
+	void addBoundedSpeed(const std::vector<rbd::MultiBody>& mbs, 
+		const std::string& bodyName,
 		const Eigen::Vector3d& bodyPoint, const Eigen::MatrixXd& dof,
 		const Eigen::VectorXd& speed);
 
@@ -564,17 +566,18 @@ public:
 		* @param lowerSpeed Lower velocity \f$ \underline{v} \in \mathbb{R}^{n} \f$.
 		* @param upperSpeed Upper velocity \f$ \overline{v} \in \mathbb{R}^{n} \f$.
 		*/
-	void addBoundedSpeed(const std::vector<rbd::MultiBody>& mbs, int bodyId,
+	void addBoundedSpeed(const std::vector<rbd::MultiBody>& mbs,
+		const std::string& bodyName,
 		const Eigen::Vector3d& bodyPoint, const Eigen::MatrixXd& dof,
 		const Eigen::VectorXd& lowerSpeed, const Eigen::VectorXd& upperSpeed);
 
 	/**
 		* Remove a bounded speed constraint.
-		* @param bodyId Remove the constraint apply on bodyId.
+		* @param bodyName Remove the constraint applied on bodyName.
 		* @return true if the constraint has been removed false if bodyId
 		* was associated with no constraint.
 		*/
-	bool removeBoundedSpeed(int bodyId);
+	bool removeBoundedSpeed(const std::string& bodyName);
 
 	/// Remove all bounded speed constraint.
 	void resetBoundedSpeeds();
@@ -607,14 +610,15 @@ private:
 	struct BoundedSpeedData
 	{
 		BoundedSpeedData(rbd::Jacobian j, const Eigen::MatrixXd& d,
-			const Eigen::VectorXd& ls, const Eigen::VectorXd& us, int bId):
+			const Eigen::VectorXd& ls, const Eigen::VectorXd& us,
+			const std::string& bName):
 			jac(j),
 			bodyPoint(j.point()),
 			dof(d),
 			lSpeed(ls),
 			uSpeed(us),
 			body(j.jointsPath().back()),
-			bodyId(bId)
+			bodyName(bName)
 		{}
 
 		rbd::Jacobian jac;
@@ -622,7 +626,7 @@ private:
 		Eigen::MatrixXd dof;
 		Eigen::VectorXd lSpeed, uSpeed;
 		int body;
-		int bodyId;
+		std::string bodyName;
 	};
 
 private:

--- a/src/QPContactConstr.cpp
+++ b/src/QPContactConstr.cpp
@@ -166,20 +166,21 @@ void ContactConstr::updateNrVars(const std::vector<rbd::MultiBody>& mbs,
 			dof = it->second;
 		}
 		std::vector<ContactSideData> contacts;
-		auto addContact = [&mbs, &data, &contacts](int rIndex, int bId,
+		auto addContact = [&mbs, &data, &contacts](int rIndex,
+			const std::string& bName,
 			double sign, const sva::PTransformd& point)
 		{
 			if(mbs[rIndex].nrDof() > 0)
 			{
 				contacts.emplace_back(rIndex, data.alphaDBegin(rIndex), sign,
-															rbd::Jacobian(mbs[rIndex], bId), point);
+							rbd::Jacobian(mbs[rIndex], bName), point);
 			}
 		};
-		addContact(cC.cId.r1Index, cC.cId.r1BodyId, 1., cC.X_b1_cf);
-		addContact(cC.cId.r2Index, cC.cId.r2BodyId, -1., cC.X_b1_cf*cC.X_b1_b2.inv());
+		addContact(cC.cId.r1Index, cC.cId.r1BodyName, 1., cC.X_b1_cf);
+		addContact(cC.cId.r2Index, cC.cId.r2BodyName, -1., cC.X_b1_cf*cC.X_b1_b2.inv());
 
-		int b1Index = mbs[cC.cId.r1Index].bodyIndexById(cC.cId.r1BodyId);
-		int b2Index = mbs[cC.cId.r2Index].bodyIndexById(cC.cId.r2BodyId);
+		int b1Index = mbs[cC.cId.r1Index].bodyIndexByName(cC.cId.r1BodyName);
+		int b2Index = mbs[cC.cId.r2Index].bodyIndexByName(cC.cId.r2BodyName);
 		cont_.emplace_back(std::move(contacts), dof, b1Index, b2Index, cC.X_b1_b2,
 			cC.X_b1_cf, cC.cId);
 	}

--- a/src/QPContacts.cpp
+++ b/src/QPContacts.cpp
@@ -84,17 +84,18 @@ FrictionCone::FrictionCone(const Eigen::Matrix3d& frame, int nrGen, double mu,
 ContactId::ContactId():
 	r1Index(-1),
 	r2Index(-1),
-	r1BodyId(-1),
-	r2BodyId(-1),
+	r1BodyName(""),
+	r2BodyName(""),
 	ambiguityId(-1)
 {}
 
 
-ContactId::ContactId(int r1I, int r2I, int r1BId, int r2BId, int ambId):
+ContactId::ContactId(int r1I, int r2I,
+	const std::string& r1BName, const std::string& r2BName, int ambId):
 	r1Index(r1I),
 	r2Index(r2I),
-	r1BodyId(r1BId),
-	r2BodyId(r2BId),
+	r1BodyName(r1BName),
+	r2BodyName(r2BName),
 	ambiguityId(ambId)
 {}
 
@@ -102,7 +103,7 @@ ContactId::ContactId(int r1I, int r2I, int r1BId, int r2BId, int ambId):
 bool ContactId::operator==(const ContactId& cId) const
 {
 	return r1Index == cId.r1Index && r2Index == cId.r2Index &&
-	r1BodyId == cId.r1BodyId && r2BodyId == cId.r2BodyId &&
+	r1BodyName == cId.r1BodyName && r2BodyName == cId.r2BodyName &&
 	ambiguityId == cId.ambiguityId;
 }
 
@@ -116,13 +117,13 @@ bool ContactId::operator!=(const ContactId& cId) const
 bool ContactId::operator<(const ContactId& cId) const
 {
 	return r1Index < cId.r1Index ||
-		(r1Index == cId.r1Index && r1BodyId < cId.r1BodyId) ||
-		(r1Index == cId.r1Index && r1BodyId == cId.r1BodyId &&
+		(r1Index == cId.r1Index && r1BodyName < cId.r1BodyName) ||
+		(r1Index == cId.r1Index && r1BodyName == cId.r1BodyName &&
 		r2Index < cId.r2Index) ||
-		(r1Index == cId.r1Index && r1BodyId == cId.r1BodyId &&
-		r2Index == cId.r2Index && r2BodyId < cId.r2BodyId) ||
-		(r1Index == cId.r1Index && r1BodyId == cId.r1BodyId &&
-		r2Index == cId.r2Index && r2BodyId == cId.r2BodyId &&
+		(r1Index == cId.r1Index && r1BodyName == cId.r1BodyName &&
+		r2Index == cId.r2Index && r2BodyName < cId.r2BodyName) ||
+		(r1Index == cId.r1Index && r1BodyName == cId.r1BodyName &&
+		r2Index == cId.r2Index && r2BodyName == cId.r2BodyName &&
 		ambiguityId < cId.ambiguityId);
 }
 
@@ -135,13 +136,13 @@ bool ContactId::operator<(const ContactId& cId) const
 
 
 UnilateralContact::UnilateralContact(int r1I, int r2I,
-	int r1BId, int r2BId,
+	const std::string& r1BName, const std::string& r2BName,
 	std::vector<Eigen::Vector3d> r1P,
 	const Eigen::Matrix3d& r1Frame,
 	const sva::PTransformd& Xbb,
 	int nrGen, double mu,
 	const sva::PTransformd& Xbcf):
-	contactId(r1I, r2I, r1BId, r2BId),
+	contactId(r1I, r2I, r1BName, r2BName),
 	r1Points(std::move(r1P)),
 	r2Points(),
 	r1Cone(r1Frame, nrGen, mu),
@@ -154,13 +155,13 @@ UnilateralContact::UnilateralContact(int r1I, int r2I,
 
 
 UnilateralContact::UnilateralContact(int r1I, int r2I,
-	int r1BId, int r2BId, int ambId,
+	const std::string& r1BName, const std::string& r2BName, int ambId,
 	std::vector<Eigen::Vector3d> r1P,
 	const Eigen::Matrix3d& r1Frame,
 	const sva::PTransformd& Xbb,
 	int nrGen, double mu,
 	const sva::PTransformd& Xbcf):
-	contactId(r1I, r2I, r1BId, r2BId, ambId),
+	contactId(r1I, r2I, r1BName, r2BName, ambId),
 	r1Points(std::move(r1P)),
 	r2Points(),
 	r1Cone(r1Frame, nrGen, mu),
@@ -343,13 +344,13 @@ void UnilateralContact::construct(const Eigen::MatrixXd& r1Frame, int nrGen, dou
 
 
 BilateralContact::BilateralContact(int r1I, int r2I,
-	int r1BId, int r2BId,
+	const std::string& r1BName, const std::string& r2BName,
 	std::vector<Eigen::Vector3d> r1P,
 	const std::vector<Eigen::Matrix3d>& r1Frames,
 	const sva::PTransformd& Xbb,
 	int nrGen, double mu,
 	const sva::PTransformd& Xbcf):
-	contactId(r1I, r2I, r1BId, r2BId),
+	contactId(r1I, r2I, r1BName, r2BName),
 	r1Points(std::move(r1P)),
 	r2Points(),
 	r1Cones(r1Points.size()),
@@ -362,13 +363,14 @@ BilateralContact::BilateralContact(int r1I, int r2I,
 
 
 BilateralContact::BilateralContact(int r1I, int r2I,
-	int r1BId, int r2BId, int ambId,
+	const std::string& r1BName, const std::string& r2BName,
+	int ambId,
 	std::vector<Eigen::Vector3d> r1P,
 	const std::vector<Eigen::Matrix3d>& r1Frames,
 	const sva::PTransformd& Xbb,
 	int nrGen, double mu,
 	const sva::PTransformd& Xbcf):
-	contactId(r1I, r2I, r1BId, r2BId, ambId),
+	contactId(r1I, r2I, r1BName, r2BName, ambId),
 	r1Points(std::move(r1P)),
 	r2Points(),
 	r1Cones(r1Points.size()),

--- a/src/QPContacts.h
+++ b/src/QPContacts.h
@@ -69,12 +69,13 @@ struct TASKS_DLLAPI ContactId
 	/**
 		* @param r1Index First robot imply in the contact.
 		* @param r2Index Second robot imply in the contact.
-		* @param r1BodyId Body id of robot r1Index imply in the contact.
-		* @param r2BodyId Body id of robot r2Index imply in the contact.
+		* @param r1BodyName Body name of robot r1Index imply in the contact.
+		* @param r2BodyName Body name of robot r2Index imply in the contact.
 		* @param ambiguityId If two or more contacts have the same r1Index, r2Index,
 		* r1BodyId, r2BodyId the ambiguityId is used to dissociate them.
 		*/
-	ContactId(int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+	ContactId(int r1Index, int r2Index,
+		const std::string& r1BodyName, const std::string& r2BodyName,
 		int ambiguityId=-1);
 
 	bool operator==(const ContactId& cId) const;
@@ -83,7 +84,7 @@ struct TASKS_DLLAPI ContactId
 	bool operator<(const ContactId& cId) const;
 
 	int r1Index, r2Index;
-	int r1BodyId, r2BodyId;
+	std::string r1BodyName, r2BodyName;
 	int ambiguityId;
 };
 
@@ -100,8 +101,8 @@ struct TASKS_DLLAPI UnilateralContact
 	/**
 		* @param r1Index First robot imply in the contact.
 		* @param r2Index Second robot imply in the contact.
-		* @param r1BodyId Body id of robot r1Index imply in the contact.
-		* @param r2BodyId Body id of robot r2Index imply in the contact.
+		* @param r1BodyName Body name of robot r1Index imply in the contact.
+		* @param r2BodyName Body name of robot r2Index imply in the contact.
 		* @param r1Points Contact points in r1BodyId frame.
 		* @param r1Frame Friction cone frame in rbBodyId frame.
 		* @param X_b1_b2 Transformation between r1BodyId and r2BodyId frame.
@@ -111,7 +112,8 @@ struct TASKS_DLLAPI UnilateralContact
 		* the contact constraints.
 		* @see ContactConstrCommon::addDofContact
 		*/
-	UnilateralContact(int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+	UnilateralContact(int r1Index, int r2Index,
+		const std::string& r1BodyName, const std::string& r2BodyName,
 		std::vector<Eigen::Vector3d> r1Points,
 		const Eigen::Matrix3d& r1Frame,
 		const sva::PTransformd& X_b1_b2,
@@ -121,8 +123,8 @@ struct TASKS_DLLAPI UnilateralContact
 	/**
 		* @param r1Index First robot imply in the contact.
 		* @param r2Index Second robot imply in the contact.
-		* @param r1BodyId Body id of robot r1Index imply in the contact.
-		* @param r2BodyId Body id of robot r2Index imply in the contact.
+		* @param r1BodyName Body name of robot r1Index imply in the contact.
+		* @param r2BodyName Body name of robot r2Index imply in the contact.
 		* @param ambId ambiguityId.
 		* @param r1Points Contact points in r1BodyId frame.
 		* @param r1Frame Friction cone frame in rbBodyId frame.
@@ -134,7 +136,8 @@ struct TASKS_DLLAPI UnilateralContact
 		* @see ContactConstrCommon::addDofContact
 		* @see ContactId::ContactId
 		*/
-	UnilateralContact(int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+	UnilateralContact(int r1Index, int r2Index,
+		const std::string& r1BodyName, const std::string& r2BodyName,
 		int ambId, std::vector<Eigen::Vector3d> r1Points,
 		const Eigen::Matrix3d& r1Frame,
 		const sva::PTransformd& X_b1_b2,
@@ -233,8 +236,8 @@ struct TASKS_DLLAPI BilateralContact
 	/**
 		* @param r1Index First robot imply in the contact.
 		* @param r2Index Second robot imply in the contact.
-		* @param r1BodyId Body id of robot r1Index imply in the contact.
-		* @param r2BodyId Body id of robot r2Index imply in the contact.
+		* @param r1BodyName Body name of robot r1Index imply in the contact.
+		* @param r2BodyName Body name of robot r2Index imply in the contact.
 		* @param r1Points Contact points in r1BodyId frame.
 		* @param r1Frames Friction cone frame in r1Points order in rbBodyId frame.
 		* @param X_b1_b2 Transformation between r1BodyId and r2BodyId frame.
@@ -245,7 +248,7 @@ struct TASKS_DLLAPI BilateralContact
 		* @see ContactConstrCommon::addDofContact
 		*/
 	BilateralContact(int r1Index, int r2Index,
-		int r1BodyId, int r2BodyId,
+		const std::string& r1BodyName, const std::string& r2BodyName,
 		std::vector<Eigen::Vector3d> r1Points,
 		const std::vector<Eigen::Matrix3d>& r1Frames,
 		const sva::PTransformd& X_b1_b2,
@@ -255,8 +258,8 @@ struct TASKS_DLLAPI BilateralContact
 	/**
 		* @param r1Index First robot imply in the contact.
 		* @param r2Index Second robot imply in the contact.
-		* @param r1BodyId Body id of robot r1Index imply in the contact.
-		* @param r2BodyId Body id of robot r2Index imply in the contact.
+		* @param r1BodyName Body id of robot r1Index imply in the contact.
+		* @param r2BodyName Body id of robot r2Index imply in the contact.
 		* @param ambId ambiguityId.
 		* @param r1Points Contact points in r1BodyId frame.
 		* @param r1Frames Friction cone frame in r1Points order in rbBodyId frame.
@@ -269,8 +272,8 @@ struct TASKS_DLLAPI BilateralContact
 		* @see ContactId::ContactId
 		*/
 	BilateralContact(int r1Index, int r2Index,
-		int r1BodyId, int r2BodyId, int ambId,
-		std::vector<Eigen::Vector3d> r1Points,
+		const std::string& r1BodyName, const std::string& r2BodyName,
+		int ambId, std::vector<Eigen::Vector3d> r1Points,
 		const std::vector<Eigen::Matrix3d>& r1Frames,
 		const sva::PTransformd& X_b1_b2,
 		int nrGen, double mu,

--- a/src/QPMotionConstr.cpp
+++ b/src/QPMotionConstr.cpp
@@ -62,8 +62,8 @@ void PositiveLambda::updateNrVars(const std::vector<rbd::MultiBody>& /* mbs */,
 	for(std::size_t i = 0; i < allC.size(); ++i)
 	{
 		cont_.push_back({allC[i].contactId,
-										data.lambdaBegin(int(i)),
-										allC[i].nrLambda()});
+				data.lambdaBegin(int(i)),
+				allC[i].nrLambda()});
 	}
 }
 
@@ -80,7 +80,7 @@ std::string PositiveLambda::nameBound() const
 }
 
 
-std::string PositiveLambda::descBound(const std::vector<rbd::MultiBody>& mbs,
+std::string PositiveLambda::descBound(const std::vector<rbd::MultiBody>& /* mbs */,
 	int line)
 {
 	std::ostringstream oss;
@@ -91,10 +91,8 @@ std::string PositiveLambda::descBound(const std::vector<rbd::MultiBody>& mbs,
 		int end = begin + cd.nrLambda;
 		if(line >= begin && line < end)
 		{
-			const rbd::MultiBody& mb1 = mbs[cd.cId.r1Index];
-			const rbd::MultiBody& mb2 = mbs[cd.cId.r2Index];
-			oss << "Body 1: " << mb1.body(mb1.bodyIndexById(cd.cId.r1BodyId)).name() << std::endl;
-			oss << "Body 2: " << mb2.body(mb2.bodyIndexById(cd.cId.r2BodyId)).name() << std::endl;
+			oss << "Body 1: " << cd.cId.r1BodyName << std::endl;
+			oss << "Body 2: " << cd.cId.r2BodyName << std::endl;
 			break;
 		}
 	}
@@ -127,12 +125,12 @@ const Eigen::VectorXd& PositiveLambda::Upper() const
 
 
 MotionConstrCommon::ContactData::ContactData(const rbd::MultiBody& mb,
-	int bId, int lB,
+	const std::string& bName, int lB,
 	std::vector<Eigen::Vector3d> pts,
 	const std::vector<FrictionCone>& cones):
 	bodyIndex(),
 	lambdaBegin(lB),
-	jac(mb, bId),
+	jac(mb, bName),
 	points(std::move(pts)),
 	minusGenerators(cones.size())
 {
@@ -215,13 +213,13 @@ void MotionConstrCommon::updateNrVars(const std::vector<rbd::MultiBody>& mbs,
 		const BilateralContact& c = cCont[i];
 		if(robotIndex_ == c.contactId.r1Index)
 		{
-			cont_.emplace_back(mb, c.contactId.r1BodyId, data.lambdaBegin(int(i)),
+			cont_.emplace_back(mb, c.contactId.r1BodyName, data.lambdaBegin(int(i)),
 				c.r1Points, c.r1Cones);
 		}
 		// we don't use else to manage self contact on the robot
 		if(robotIndex_ == c.contactId.r2Index)
 		{
-			cont_.emplace_back(mb, c.contactId.r2BodyId, data.lambdaBegin(int(i)),
+			cont_.emplace_back(mb, c.contactId.r2BodyName, data.lambdaBegin(int(i)),
 				c.r2Points, c.r2Cones);
 		}
 	}
@@ -372,7 +370,7 @@ MotionSpringConstr::MotionSpringConstr(
 	const rbd::MultiBody& mb = mbs[robotIndex_];
 	for(const SpringJoint& sj: springs)
 	{
-		int index = mb.jointIndexById(sj.jointId);
+		int index = mb.jointIndexByName(sj.jointName);
 		int posInDof = mb.jointPosInDof(index);
 		springs_.push_back({index, posInDof, sj.K, sj.C, sj.O});
 	}

--- a/src/QPMotionConstr.h
+++ b/src/QPMotionConstr.h
@@ -111,12 +111,13 @@ protected:
 	{
 		ContactData() {}
 		ContactData(const rbd::MultiBody& mb,
-			int bodyId, int lambdaBegin,
+			const std::string& bodyName, int lambdaBegin,
 			std::vector<Eigen::Vector3d> points,
 			const std::vector<FrictionCone>& cones);
 
 
-		int bodyIndex, lambdaBegin;
+		std::string bodyIndex;
+		int lambdaBegin;
 		rbd::Jacobian jac;
 		std::vector<Eigen::Vector3d> points;
 		// BEWARE generator are minus to avoid one multiplication by -1 in the
@@ -165,11 +166,11 @@ protected:
 struct SpringJoint
 {
 	SpringJoint(){}
-	SpringJoint(int jId, double K, double C, double O):
-		jointId(jId),K(K),C(C),O(O)
+	SpringJoint(const std::string& jName, double K, double C, double O):
+		jointName(jName),K(K),C(C),O(O)
 	{}
 
-	int jointId;
+	std::string jointName;
 	double K, C, O;
 };
 

--- a/src/QPTasks.cpp
+++ b/src/QPTasks.cpp
@@ -551,48 +551,48 @@ const Eigen::VectorXd& TargetObjectiveTask::C() const
 
 
 JointsSelector JointsSelector::ActiveJoints(const std::vector<rbd::MultiBody>& mbs,
-	int robotIndex, HighLevelTask* hl, const std::vector<int>& activeJointsId)
+	int robotIndex, HighLevelTask* hl, const std::vector<std::string>& activeJointsName)
 {
-	return JointsSelector(mbs, robotIndex, hl, activeJointsId);
+	return JointsSelector(mbs, robotIndex, hl, activeJointsName);
 }
 
 
 JointsSelector JointsSelector::UnactiveJoints(const std::vector<rbd::MultiBody>& mbs,
-	int robotIndex, HighLevelTask* hl, const std::vector<int>& unactiveJointsId)
+	int robotIndex, HighLevelTask* hl, const std::vector<std::string>& unactiveJointsName)
 {
 	using namespace std::placeholders;
 	const rbd::MultiBody& mb = mbs[robotIndex];
 
-	std::vector<int> activeJointsId;
-	// sort unactiveJointsId by puting them into a set
-	std::set<int> unactiveJointsIdSet(unactiveJointsId.begin(),
-		unactiveJointsId.end());
+	std::vector<std::string> activeJointsName;
+	// sort unactiveJointsName by puting them into a set
+	std::set<std::string> unactiveJointsNameSet(unactiveJointsName.begin(),
+		unactiveJointsName.end());
 	// create a set with all joints id
-	std::set<int> jointsIdSet;
+	std::set<std::string> jointsNameSet;
 	std::transform(mb.joints().begin(), mb.joints().end(),
-		std::inserter(jointsIdSet, jointsIdSet.begin()),
-		std::bind(&rbd::Joint::id, _1));
+		std::inserter(jointsNameSet, jointsNameSet.begin()),
+		std::bind(&rbd::Joint::name, _1));
 
 	// remove unactive joints from the set
-	std::set_difference(jointsIdSet.begin(), jointsIdSet.end(),
-		unactiveJointsIdSet.begin(), unactiveJointsIdSet.end(),
-		std::inserter(activeJointsId, activeJointsId.begin()));
+	std::set_difference(jointsNameSet.begin(), jointsNameSet.end(),
+		unactiveJointsNameSet.begin(), unactiveJointsNameSet.end(),
+		std::inserter(activeJointsName, activeJointsName.begin()));
 
-	return JointsSelector(mbs, robotIndex, hl, activeJointsId);
+	return JointsSelector(mbs, robotIndex, hl, activeJointsName);
 }
 
 
 JointsSelector::JointsSelector(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-	HighLevelTask* hl, const std::vector<int>& selectedJointsId):
+	HighLevelTask* hl, const std::vector<std::string>& selectedJointsName):
 	jac_(Eigen::MatrixXd::Zero(hl->dim(), mbs[robotIndex].nrDof())),
 	selectedJoints_(),
 	hl_(hl)
 {
 	const rbd::MultiBody& mb = mbs[robotIndex];
-	selectedJoints_.reserve(selectedJointsId.size());
-	for(int jId: selectedJointsId)
+	selectedJoints_.reserve(selectedJointsName.size());
+	for(const std::string& jName: selectedJointsName)
 	{
-		int index = mb.jointIndexById(jId);
+		int index = mb.jointIndexByName(jName);
 		selectedJoints_.push_back({mb.jointPosInDof(index), mb.joint(index).dof()});
 	}
 	// sort data in posInDof order
@@ -675,7 +675,7 @@ TorqueTask::TorqueTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
 }
 
 TorqueTask::TorqueTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-                       const TorqueBound& tb, int efId,
+                       const TorqueBound& tb, const std::string& efName,
                        double weight):
   Task(weight),
   robotIndex_(robotIndex),
@@ -686,7 +686,7 @@ TorqueTask::TorqueTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
   Q_(mbs[robotIndex].nrDof(), mbs[robotIndex].nrDof()),
   C_(mbs[robotIndex].nrDof())
 {
-  rbd::Jacobian jac(mbs[robotIndex], efId);
+  rbd::Jacobian jac(mbs[robotIndex], efName);
   jointSelector_.setZero();
   for(auto i : jac.jointsPath())
   {
@@ -768,7 +768,7 @@ void PostureTask::jointsStiffness(const std::vector<rbd::MultiBody>& mbs,
 	const rbd::MultiBody& mb = mbs[robotIndex_];
 	for(const JointStiffness& js: jsv)
 	{
-		int jointIndex = mb.jointIndexById(js.jointId);
+		int jointIndex = mb.jointIndexByName(js.jointName);
 		jointDatas_.push_back({js.stiffness, 2.*std::sqrt(js.stiffness),
 													mb.jointPosInDof(jointIndex),
 													mb.joint(jointIndex).dof()});
@@ -784,7 +784,7 @@ void PostureTask::jointsGains(const std::vector<rbd::MultiBody> &mbs,
 	const rbd::MultiBody& mb = mbs[robotIndex_];
 	for(const JointGains& jg: jgv)
 	{
-		int jointIndex = mb.jointIndexById(jg.jointId);
+		int jointIndex = mb.jointIndexByName(jg.jointName);
 		jointDatas_.push_back({jg.stiffness, jg.damping, mb.jointPosInDof(jointIndex),
 			mb.joint(jointIndex).dof()});
 	}
@@ -846,8 +846,9 @@ const Eigen::VectorXd& PostureTask::eval() const
 
 
 PositionTask::PositionTask(const std::vector<rbd::MultiBody>& mbs, int rI,
-	int bodyId, const Eigen::Vector3d& pos, const Eigen::Vector3d& bodyPoint):
-	pt_(mbs[rI], bodyId, pos, bodyPoint),
+	const std::string& bodyName, const Eigen::Vector3d& pos,
+	const Eigen::Vector3d& bodyPoint):
+	pt_(mbs[rI], bodyName, pos, bodyPoint),
 	robotIndex_(rI)
 {
 }
@@ -897,17 +898,17 @@ const Eigen::VectorXd& PositionTask::normalAcc()
 
 
 OrientationTask::OrientationTask(const std::vector<rbd::MultiBody>& mbs,
-	int rI, int bodyId,
+	int rI, const std::string& bodyName,
 	const Eigen::Quaterniond& ori):
-	ot_(mbs[rI], bodyId, ori),
+	ot_(mbs[rI], bodyName, ori),
 	robotIndex_(rI)
 {}
 
 
 OrientationTask::OrientationTask(const std::vector<rbd::MultiBody>& mbs,
-	int rI, int bodyId,
+	int rI, const std::string& bodyName,
 	const Eigen::Matrix3d& ori):
-	ot_(mbs[rI], bodyId, ori),
+	ot_(mbs[rI], bodyName, ori),
 	robotIndex_(rI)
 {}
 
@@ -957,9 +958,9 @@ const Eigen::VectorXd& OrientationTask::normalAcc()
 
 SurfaceTransformTask::SurfaceTransformTask(const std::vector<rbd::MultiBody>& mbs,
 	int robotIndex,
-	int bodyId, const sva::PTransformd& X_0_t,
+	const std::string& bodyName, const sva::PTransformd& X_0_t,
 	const sva::PTransformd& X_b_p):
-	TransformTaskCommon(mbs, robotIndex, bodyId, X_0_t, X_b_p)
+	TransformTaskCommon(mbs, robotIndex, bodyName, X_0_t, X_b_p)
 {
 }
 
@@ -978,9 +979,9 @@ void SurfaceTransformTask::update(const std::vector<rbd::MultiBody>& mbs,
 
 
 TransformTask::TransformTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-	int bodyId, const sva::PTransformd& X_0_t,
+	const std::string& bodyName, const sva::PTransformd& X_0_t,
 	const sva::PTransformd& X_b_p, const Eigen::Matrix3d& E_0_c):
-	TransformTaskCommon(mbs, robotIndex, bodyId, X_0_t, X_b_p)
+	TransformTaskCommon(mbs, robotIndex, bodyName, X_0_t, X_b_p)
 {
 	tt_.E_0_c(E_0_c);
 }
@@ -1012,17 +1013,17 @@ void TransformTask::update(const std::vector<rbd::MultiBody>& mbs,
 
 
 SurfaceOrientationTask::SurfaceOrientationTask(const std::vector<rbd::MultiBody>& mbs,
-	int rI, int bodyId,
+	int rI, const std::string& bodyName,
 	const Eigen::Quaterniond& ori, const sva::PTransformd& X_b_s):
-	ot_(mbs[rI], bodyId, ori, X_b_s),
+	ot_(mbs[rI], bodyName, ori, X_b_s),
 	robotIndex_(rI)
 {}
 
 
 SurfaceOrientationTask::SurfaceOrientationTask(const std::vector<rbd::MultiBody>& mbs,
-	int rI, int bodyId,
+	int rI, const std::string& bodyName,
 	const Eigen::Matrix3d& ori, const sva::PTransformd& X_b_s):
-	ot_(mbs[rI], bodyId, ori, X_b_s),
+	ot_(mbs[rI], bodyName, ori, X_b_s),
 	robotIndex_(rI)
 {}
 
@@ -1071,20 +1072,20 @@ const Eigen::VectorXd& SurfaceOrientationTask::normalAcc()
 
 
 GazeTask::GazeTask(const std::vector<rbd::MultiBody>& mbs,
-	int robotIndex, int bodyId,
+	int robotIndex, const std::string& bodyName,
 	const Eigen::Vector2d& point2d, double depthEstimate,
 	const sva::PTransformd& X_b_gaze,
 	const Eigen::Vector2d& point2d_ref):
-	gazet_(mbs[robotIndex], bodyId, point2d, depthEstimate, X_b_gaze, point2d_ref),
+	gazet_(mbs[robotIndex], bodyName, point2d, depthEstimate, X_b_gaze, point2d_ref),
 	robotIndex_(robotIndex)
 {}
 
 
 GazeTask::GazeTask(const std::vector<rbd::MultiBody>& mbs,
-	int robotIndex, int bodyId,
+	int robotIndex, const std::string& bodyName,
 	const Eigen::Vector3d& point3d, const sva::PTransformd& X_b_gaze,
 	const Eigen::Vector2d& point2d_ref):
-	gazet_(mbs[robotIndex], bodyId, point3d, X_b_gaze, point2d_ref),
+	gazet_(mbs[robotIndex], bodyName, point3d, X_b_gaze, point2d_ref),
 	robotIndex_(robotIndex)
 {}
 
@@ -1133,10 +1134,10 @@ const Eigen::VectorXd& GazeTask::normalAcc()
 
 
 PositionBasedVisServoTask::PositionBasedVisServoTask(const std::vector<rbd::MultiBody>& mbs,
-	int robotIndex, int bodyId,
+	int robotIndex, const std::string& bodyName,
 	const sva::PTransformd& X_t_s,
 	const sva::PTransformd& X_b_s):
-	pbvst_(mbs[robotIndex], bodyId, X_t_s, X_b_s),
+	pbvst_(mbs[robotIndex], bodyName, X_t_s, X_b_s),
 	robotIndex_(robotIndex)
 {}
 
@@ -1393,7 +1394,8 @@ void MultiCoMTask::init(const std::vector<rbd::MultiBody>& mbs)
 
 MultiRobotTransformTask::MultiRobotTransformTask(
 	const std::vector<rbd::MultiBody>& mbs,
-	int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+	int r1Index, int r2Index,
+	const std::string& r1BodyName, const std::string& r2BodyName,
 	const sva::PTransformd& X_r1b_r1s, const sva::PTransformd& X_r2b_r2s,
 	double stiffness, double weight):
 	Task(weight),
@@ -1403,7 +1405,7 @@ MultiRobotTransformTask::MultiRobotTransformTask(
 	dimWeight_(Eigen::Vector6d::Ones()),
 	posInQ_(2, -1),
 	robotIndexes_{{r1Index, r2Index}},
-	mrtt_(mbs, r1Index, r2Index, r1BodyId, r2BodyId, X_r1b_r1s, X_r2b_r2s),
+	mrtt_(mbs, r1Index, r2Index, r1BodyName, r2BodyName, X_r1b_r1s, X_r2b_r2s),
 	Q_(),
 	C_(),
 	CSum_(),
@@ -1750,9 +1752,9 @@ const Eigen::VectorXd& GripperTorqueTask::C() const
 
 
 LinVelocityTask::LinVelocityTask(const std::vector<rbd::MultiBody>& mbs,
-	int rI, int bodyId,
+	int rI, const std::string& bodyName,
 	const Eigen::Vector3d& speed, const Eigen::Vector3d& bodyPoint):
-	pt_(mbs[rI], bodyId, speed, bodyPoint),
+	pt_(mbs[rI], bodyName, speed, bodyPoint),
 	robotIndex_(rI)
 {
 }
@@ -1802,12 +1804,12 @@ const Eigen::VectorXd& LinVelocityTask::normalAcc()
 
 
 OrientationTrackingTask::OrientationTrackingTask(
-	const std::vector<rbd::MultiBody>& mbs, int rI, int bodyId,
+	const std::vector<rbd::MultiBody>& mbs, int rI, const std::string& bodyName,
 	const Eigen::Vector3d& bodyPoint, const Eigen::Vector3d& bodyAxis,
-	const std::vector<int>& trackingJointsId,
+	const std::vector<std::string>& trackingJointsName,
 	const Eigen::Vector3d& trackedPoint):
 	robotIndex_(rI),
-	ott_(mbs[rI], bodyId, bodyPoint, bodyAxis, trackingJointsId, trackedPoint),
+	ott_(mbs[rI], bodyName, bodyPoint, bodyAxis, trackingJointsName, trackedPoint),
 	alphaVec_(mbs[rI].nrDof()),
 	speed_(3),
 	normalAcc_(3)
@@ -1911,8 +1913,9 @@ const Eigen::VectorXd& RelativeDistTask::normalAcc()
 
 
 VectorOrientationTask::VectorOrientationTask(const std::vector<rbd::MultiBody>& mbs, int rI,
-	int bodyId, const Eigen::Vector3d& bodyVector, const Eigen::Vector3d& targetVector):
-	vot_(mbs[rI], bodyId, bodyVector, targetVector),
+	const std::string& bodyName, const Eigen::Vector3d& bodyVector,
+	const Eigen::Vector3d& targetVector):
+	vot_(mbs[rI], bodyName, bodyVector, targetVector),
 	robotIndex_(rI)
 {
 }

--- a/src/QPTasks.h
+++ b/src/QPTasks.h
@@ -296,9 +296,11 @@ class TASKS_DLLAPI JointsSelector : public HighLevelTask
 {
 public:
 	static JointsSelector ActiveJoints(const std::vector<rbd::MultiBody>& mbs,
-		int robotIndex, HighLevelTask* hl, const std::vector<int>& activeJointsId);
+		int robotIndex, HighLevelTask* hl,
+		const std::vector<std::string>& activeJointsName);
 	static JointsSelector UnactiveJoints(const std::vector<rbd::MultiBody>& mbs,
-		int robotIndex, HighLevelTask* hl, const std::vector<int>& unactiveJointsId);
+		int robotIndex, HighLevelTask* hl,
+		const std::vector<std::string>& unactiveJointsName);
 
 public:
 	struct SelectedData
@@ -308,7 +310,7 @@ public:
 
 public:
 	JointsSelector(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		HighLevelTask* hl, const std::vector<int>& selectedJointsId);
+		HighLevelTask* hl, const std::vector<std::string>& selectedJointsName);
 
 	const std::vector<SelectedData> selectedJoints() const
 	{
@@ -336,39 +338,39 @@ private:
 struct JointStiffness
 {
 	JointStiffness():
-		jointId(),
+		jointName(),
 		stiffness()
 	{}
-	JointStiffness(int jId, double stif):
-		jointId(jId),
+	JointStiffness(const std::string& jName, double stif):
+		jointName(jName),
 		stiffness(stif)
 	{}
 
-	int jointId;
+	std::string jointName;
 	double stiffness;
 };
 
 struct JointGains
 {
 	JointGains():
-		jointId(),
+		jointName(),
 		stiffness(),
 		damping()
 	{}
-	JointGains(int jId, double stif) :
-		jointId(jId),
+	JointGains(const std::string& jName, double stif) :
+		jointName(jName),
 		stiffness(stif)
 	{
 		damping = 2.*std::sqrt(stif);
 	}
 
-	JointGains(int jId, double stif, double damp):
-		jointId(jId),
+	JointGains(const std::string& jName, double stif, double damp):
+		jointName(jName),
 		stiffness(stif),
 		damping(damp)
 	{}
 
-	int jointId;
+	std::string jointName;
 	double stiffness, damping;
 };
 
@@ -383,7 +385,7 @@ public:
                    double weight);
 
         TorqueTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-                   const TorqueBound& tb, int efId,
+                   const TorqueBound& tb, const std::string& efName,
                    double weight);
 
 	virtual void updateNrVars(const std::vector<rbd::MultiBody>& mbs,
@@ -506,7 +508,7 @@ class TASKS_DLLAPI PositionTask : public HighLevelTask
 {
 public:
 	PositionTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const Eigen::Vector3d& pos,
+		const std::string& bodyName, const Eigen::Vector3d& pos,
 		const Eigen::Vector3d& bodyPoint=Eigen::Vector3d::Zero());
 
 	tasks::PositionTask& task()
@@ -555,9 +557,9 @@ class TASKS_DLLAPI OrientationTask : public HighLevelTask
 {
 public:
 	OrientationTask(const std::vector<rbd::MultiBody>& mbs, int robodIndex,
-		int bodyId, const Eigen::Quaterniond& ori);
+		const std::string& bodyName, const Eigen::Quaterniond& ori);
 	OrientationTask(const std::vector<rbd::MultiBody>& mbs, int robodIndex,
-		int bodyId, const Eigen::Matrix3d& ori);
+		const std::string& bodyName, const Eigen::Matrix3d& ori);
 
 	tasks::OrientationTask& task()
 	{
@@ -601,9 +603,9 @@ class TASKS_DLLAPI TransformTaskCommon : public HighLevelTask
 {
 public:
 	TransformTaskCommon(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const sva::PTransformd& X_0_t,
+		const std::string& bodyName, const sva::PTransformd& X_0_t,
 		const sva::PTransformd& X_b_p=sva::PTransformd::Identity())
-	:  tt_(mbs[robotIndex], bodyId, X_0_t, X_b_p),
+	:  tt_(mbs[robotIndex], bodyName, X_0_t, X_b_p),
 	   robotIndex_(robotIndex)
 	{
 	}
@@ -670,7 +672,7 @@ class TASKS_DLLAPI SurfaceTransformTask : public TransformTaskCommon<tasks::Surf
 {
 public:
 	SurfaceTransformTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const sva::PTransformd& X_0_t,
+		const std::string& bodyName, const sva::PTransformd& X_0_t,
 		const sva::PTransformd& X_b_p=sva::PTransformd::Identity());
 
 	virtual void update(const std::vector<rbd::MultiBody>& mb,
@@ -685,7 +687,7 @@ class TASKS_DLLAPI TransformTask : public TransformTaskCommon<tasks::TransformTa
 {
 public:
 	TransformTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const sva::PTransformd& X_0_t,
+		const std::string& bodyName, const sva::PTransformd& X_0_t,
 		const sva::PTransformd& X_b_p=sva::PTransformd::Identity(),
 		const Eigen::Matrix3d& E_0_c=Eigen::Matrix3d::Identity());
 
@@ -703,9 +705,11 @@ class TASKS_DLLAPI SurfaceOrientationTask : public HighLevelTask
 {
 public:
 	SurfaceOrientationTask(const std::vector<rbd::MultiBody>& mbs, int robodIndex,
-			int bodyId, const Eigen::Quaterniond& ori, const sva::PTransformd& X_b_s);
+			const std::string& bodyName, const Eigen::Quaterniond& ori,
+			const sva::PTransformd& X_b_s);
 	SurfaceOrientationTask(const std::vector<rbd::MultiBody>& mbs, int robodIndex,
-			int bodyId, const Eigen::Matrix3d& ori, const sva::PTransformd& X_b_s);
+			const std::string& bodyName, const Eigen::Matrix3d& ori,
+			const sva::PTransformd& X_b_s);
 
 	tasks::SurfaceOrientationTask& task()
 	{
@@ -748,11 +752,12 @@ class TASKS_DLLAPI GazeTask : public HighLevelTask
 {
 public:
 	GazeTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const Eigen::Vector2d& point2d, double depthEstimate,
-		const sva::PTransformd& X_b_gaze,
+		const std::string& bodyName, const Eigen::Vector2d& point2d,
+		double depthEstimate, const sva::PTransformd& X_b_gaze,
 		const Eigen::Vector2d& point2d_ref = Eigen::Vector2d::Zero());
 	GazeTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const Eigen::Vector3d& point3d, const sva::PTransformd& X_b_gaze,
+		const std::string& bodyName, const Eigen::Vector3d& point3d,
+		const sva::PTransformd& X_b_gaze,
 		const Eigen::Vector2d& point2d_ref = Eigen::Vector2d::Zero());
 
 	tasks::GazeTask& task()
@@ -792,7 +797,7 @@ class TASKS_DLLAPI PositionBasedVisServoTask : public HighLevelTask
 {
 public:
 	PositionBasedVisServoTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const sva::PTransformd& X_t_s,
+		const std::string& bodyName, const sva::PTransformd& X_t_s,
 		const sva::PTransformd& X_b_s=sva::PTransformd::Identity());
 
 	tasks::PositionBasedVisServoTask& task()
@@ -941,7 +946,8 @@ class TASKS_DLLAPI MultiRobotTransformTask : public Task
 {
 public:
 	MultiRobotTransformTask(const std::vector<rbd::MultiBody>& mbs,
-		int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+		int r1Index, int r2Index,
+		const std::string& r1BodyName, const std::string& r2BodyName,
 		const sva::PTransformd& X_r1b_r1s, const sva::PTransformd& X_r2b_r2s,
 		double stiffness, double weight);
 
@@ -1129,7 +1135,7 @@ class TASKS_DLLAPI LinVelocityTask : public HighLevelTask
 {
 public:
 	LinVelocityTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const Eigen::Vector3d& vel,
+		const std::string& bodyName, const Eigen::Vector3d& vel,
 		const Eigen::Vector3d& bodyPoint=Eigen::Vector3d::Zero());
 
 	tasks::LinVelocityTask& task()
@@ -1178,9 +1184,9 @@ class TASKS_DLLAPI OrientationTrackingTask : public HighLevelTask
 {
 public:
 	OrientationTrackingTask(const std::vector<rbd::MultiBody>& mbs,
-		int robotIndex, int bodyId,
+		int robotIndex, const std::string& bodyName,
 		const Eigen::Vector3d& bodyPoint, const Eigen::Vector3d& bodyAxis,
-		const std::vector<int>& trackingJointsId,
+		const std::vector<std::string>& trackingJointsName,
 		const Eigen::Vector3d& trackedPoint);
 
 	tasks::OrientationTrackingTask& task()
@@ -1249,19 +1255,22 @@ public:
 		return rdt_;
 	}
 
-	void robotPoint(const rbd::MultiBody& mb, const int bId, const Eigen::Vector3d& point)
+	void robotPoint(const rbd::MultiBody& mb, const std::string& bName,
+			const Eigen::Vector3d& point)
 	{
-		int bIndex = mb.bodyIndexById(bId);
+		int bIndex = mb.bodyIndexByName(bName);
 		rdt_.robotPoint(bIndex, point);
 	}
-	void envPoint(const rbd::MultiBody& mb, const int bId, const Eigen::Vector3d& point)
+	void envPoint(const rbd::MultiBody& mb, const std::string&  bName,
+			const Eigen::Vector3d& point)
 	{
-		int bIndex = mb.bodyIndexById(bId);
+		int bIndex = mb.bodyIndexByName(bName);
 		rdt_.envPoint(bIndex, point);
 	}
-	void vector(const rbd::MultiBody& mb, const int bId, const Eigen::Vector3d& u)
+	void vector(const rbd::MultiBody& mb, const std::string& bName,
+			const Eigen::Vector3d& u)
 	{
-		int bIndex = mb.bodyIndexById(bId);
+		int bIndex = mb.bodyIndexByName(bName);
 		rdt_.vector(bIndex, u);
 	}
 
@@ -1285,7 +1294,8 @@ class VectorOrientationTask : public HighLevelTask
 {
 public:
 	VectorOrientationTask(const std::vector<rbd::MultiBody>& mbs, int robotIndex,
-		int bodyId, const Eigen::Vector3d& bodyVector, const Eigen::Vector3d& targetVector);
+		const std::string& bodyName, const Eigen::Vector3d& bodyVector,
+		const Eigen::Vector3d& targetVector);
 
 	tasks::VectorOrientationTask& task()
 	{

--- a/src/Tasks.cpp
+++ b/src/Tasks.cpp
@@ -37,12 +37,12 @@ namespace tasks
 	*/
 
 
-PositionTask::PositionTask(const rbd::MultiBody& mb, int bodyId,
+PositionTask::PositionTask(const rbd::MultiBody& mb, const std::string& bodyName,
 	const Eigen::Vector3d& pos, const Eigen::Vector3d& bodyPoint):
 	pos_(pos),
 	point_(bodyPoint),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId, bodyPoint),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName, bodyPoint),
 	eval_(3),
 	speed_(3),
 	normalAcc_(3),
@@ -144,10 +144,10 @@ const Eigen::MatrixXd& PositionTask::jacDot() const
 	*/
 
 
-OrientationTask::OrientationTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Quaterniond& ori):
+OrientationTask::OrientationTask(const rbd::MultiBody& mb, const std::string& bodyName, const Eigen::Quaterniond& ori):
 	ori_(ori.matrix()),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	eval_(3),
 	speed_(3),
 	normalAcc_(3),
@@ -157,10 +157,10 @@ OrientationTask::OrientationTask(const rbd::MultiBody& mb, int bodyId, const Eig
 }
 
 
-OrientationTask::OrientationTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Matrix3d& ori):
+OrientationTask::OrientationTask(const rbd::MultiBody& mb, const std::string& bodyName, const Eigen::Matrix3d& ori):
 	ori_(ori),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	eval_(3),
 	speed_(3),
 	normalAcc_(3),
@@ -253,12 +253,12 @@ const Eigen::MatrixXd& OrientationTask::jacDot() const
 	*/
 
 
-TransformTaskCommon::TransformTaskCommon(const rbd::MultiBody& mb, int bodyId,
+TransformTaskCommon::TransformTaskCommon(const rbd::MultiBody& mb, const std::string& bodyName,
 		const sva::PTransformd& X_0_t, const sva::PTransformd& X_b_p):
 	X_0_t_(X_0_t),
 	X_b_p_(X_b_p),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	eval_(6),
 	speed_(6),
 	normalAcc_(6),
@@ -320,9 +320,9 @@ const Eigen::MatrixXd& TransformTaskCommon::jac() const
 	*/
 
 
-SurfaceTransformTask::SurfaceTransformTask(const rbd::MultiBody& mb, int bodyId,
+SurfaceTransformTask::SurfaceTransformTask(const rbd::MultiBody& mb, const std::string& bodyName,
 		const sva::PTransformd& X_0_t, const sva::PTransformd& X_b_p):
-	TransformTaskCommon(mb, bodyId, X_0_t, X_b_p),
+	TransformTaskCommon(mb, bodyName, X_0_t, X_b_p),
 	jacMatTmp_(6, jac_.dof())
 {
 }
@@ -363,10 +363,10 @@ void SurfaceTransformTask::update(const rbd::MultiBody& mb,
 	*/
 
 
-TransformTask::TransformTask(const rbd::MultiBody& mb, int bodyId,
+TransformTask::TransformTask(const rbd::MultiBody& mb, const std::string& bodyName,
 		const sva::PTransformd& X_0_t, const sva::PTransformd& X_b_p,
 		const Eigen::Matrix3d& E_0_c):
-	TransformTaskCommon(mb, bodyId, X_0_t, X_b_p),
+	TransformTaskCommon(mb, bodyName, X_0_t, X_b_p),
 	E_0_c_(E_0_c)
 {
 }
@@ -409,16 +409,17 @@ void TransformTask::update(const rbd::MultiBody& mb,
 
 MultiRobotTransformTask::MultiRobotTransformTask(
 	const std::vector<rbd::MultiBody>& mbs,
-	int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+	int r1Index, int r2Index,
+	const std::string& r1BodyName, const std::string& r2BodyName,
 	const sva::PTransformd& X_r1b_r1s, const sva::PTransformd& X_r2b_r2s):
 	r1Index_(r1Index),
 	r2Index_(r2Index),
-	r1BodyIndex_(mbs[r1Index].bodyIndexById(r1BodyId)),
-	r2BodyIndex_(mbs[r2Index].bodyIndexById(r2BodyId)),
+	r1BodyIndex_(mbs[r1Index].bodyIndexByName(r1BodyName)),
+	r2BodyIndex_(mbs[r2Index].bodyIndexByName(r2BodyName)),
 	X_r1b_r1s_(X_r1b_r1s),
 	X_r2b_r2s_(X_r2b_r2s),
-	jacR1B_(mbs[r1Index], r1BodyId),
-	jacR2B_(mbs[r2Index], r2BodyId),
+	jacR1B_(mbs[r1Index], r1BodyName),
+	jacR2B_(mbs[r2Index], r2BodyName),
 	eval_(6),
 	speed_(6),
 	normalAcc_(6),
@@ -553,10 +554,11 @@ const Eigen::MatrixXd& MultiRobotTransformTask::jac(int index) const
 
 
 SurfaceOrientationTask::SurfaceOrientationTask(const rbd::MultiBody& mb,
-	int bodyId, const Eigen::Quaterniond& ori, const sva::PTransformd& X_b_s):
+	const std::string& bodyName, const Eigen::Quaterniond& ori,
+	const sva::PTransformd& X_b_s):
 	ori_(ori.matrix()),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	X_b_s_(X_b_s),
 	eval_(3),
 	speed_(3),
@@ -568,10 +570,10 @@ SurfaceOrientationTask::SurfaceOrientationTask(const rbd::MultiBody& mb,
 
 
 SurfaceOrientationTask::SurfaceOrientationTask(const rbd::MultiBody& mb,
-	int bodyId, const Eigen::Matrix3d& ori, const sva::PTransformd& X_b_s):
+	const std::string& bodyName, const Eigen::Matrix3d& ori, const sva::PTransformd& X_b_s):
 	ori_(ori),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	X_b_s_(X_b_s),
 	eval_(3),
 	speed_(3),
@@ -678,14 +680,14 @@ const Eigen::MatrixXd& SurfaceOrientationTask::jacDot() const
 	*/
 
 
-GazeTask::GazeTask(const rbd::MultiBody &mb, int bodyId,
+GazeTask::GazeTask(const rbd::MultiBody &mb, const std::string& bodyName,
 	const Eigen::Vector2d& point2d, double depthEstimate, const sva::PTransformd& X_b_gaze,
 	const Eigen::Vector2d& point2d_ref):
 	point2d_(point2d),
 	point2d_ref_(point2d_ref),
 	depthEstimate_(depthEstimate),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	X_b_gaze_(X_b_gaze),
 	eval_(2),
 	speed_(2),
@@ -696,12 +698,12 @@ GazeTask::GazeTask(const rbd::MultiBody &mb, int bodyId,
 }
 
 
-GazeTask::GazeTask(const rbd::MultiBody &mb, int bodyId,
+GazeTask::GazeTask(const rbd::MultiBody &mb, const std::string& bodyName,
 	const Eigen::Vector3d &point3d, const sva::PTransformd& X_b_gaze,
 	const Eigen::Vector2d& point2d_ref):
 	point2d_ref_(point2d_ref),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	X_b_gaze_(X_b_gaze),
 	eval_(2),
 	speed_(2),
@@ -781,14 +783,15 @@ const Eigen::MatrixXd& GazeTask::jacDot() const
 	*/
 
 
-PositionBasedVisServoTask::PositionBasedVisServoTask(const rbd::MultiBody &mb, int bodyId,
-	const sva::PTransformd& X_t_s, const sva::PTransformd& X_b_s):
+PositionBasedVisServoTask::PositionBasedVisServoTask(const rbd::MultiBody &mb,
+	const std::string& bodyName, const sva::PTransformd& X_t_s,
+	const sva::PTransformd& X_b_s):
 	X_t_s_(X_t_s),
 	X_b_s_(X_b_s),
 	angle_(0.),
 	axis_(Eigen::Vector3d::Zero()),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	L_pbvs_(Eigen::Matrix<double, 6, 6>::Zero()),
 	eval_(6),
 	speed_(6),
@@ -1322,12 +1325,12 @@ const Eigen::MatrixXd& MomentumTask::jacDot() const
 	*/
 
 
-LinVelocityTask::LinVelocityTask(const rbd::MultiBody& mb, int bodyId,
+LinVelocityTask::LinVelocityTask(const rbd::MultiBody& mb, const std::string& bodyName,
 	const Eigen::Vector3d& v, const Eigen::Vector3d& bodyPoint):
 	vel_(v),
 	point_(bodyPoint),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId, bodyPoint),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName, bodyPoint),
 	eval_(3),
 	speed_(3),
 	normalAcc_(3),
@@ -1427,24 +1430,25 @@ const Eigen::MatrixXd& LinVelocityTask::jacDot() const
 
 
 OrientationTrackingTask::OrientationTrackingTask(const rbd::MultiBody& mb,
-	int bodyId, const Eigen::Vector3d& bodyPoint, const Eigen::Vector3d& bodyAxis,
-	const std::vector<int>& trackingJointsId,
+	const std::string& bodyName, const Eigen::Vector3d& bodyPoint,
+	const Eigen::Vector3d& bodyAxis,
+	const std::vector<std::string>& trackingJointsName,
 	const Eigen::Vector3d& trackedPoint):
-	bodyIndex_(mb.bodyIndexById(bodyId)),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
 	bodyPoint_(bodyPoint),
 	bodyAxis_(bodyAxis),
 	zeroJacIndex_(),
 	trackedPoint_(trackedPoint),
-	jac_(mb, bodyId),
+	jac_(mb, bodyName),
 	eval_(3),
 	shortJacMat_(3, jac_.dof()),
 	jacMat_(3, mb.nrDof()),
 	jacDotMat_(3, mb.nrDof())
 {
 	std::set<int> trackingJointsIndex;
-	for(int id: trackingJointsId)
+	for(const std::string& name: trackingJointsName)
 	{
-		trackingJointsIndex.insert(mb.jointIndexById(id));
+		trackingJointsIndex.insert(mb.jointIndexByName(name));
 	}
 
 	int jacPos = 0;
@@ -1582,7 +1586,7 @@ RelativeDistTask::RelativeDistTask(const rbd::MultiBody& mb,
 
 RelativeDistTask::RelativeBodiesInfo::RelativeBodiesInfo(const rbd::MultiBody& mb,
 	const rbInfo& rbi, const Eigen::Vector3d& fixedVector) :
-	b1Index(mb.bodyIndexById(std::get<0>(rbi))),
+	b1Index(mb.bodyIndexByName(std::get<0>(rbi))),
 	r_b1_p(std::get<1>(rbi)),
 	r_0_b2p(std::get<2>(rbi)),
 	jac(mb, std::get<0>(rbi), r_b1_p),
@@ -1704,13 +1708,14 @@ const Eigen::MatrixXd& RelativeDistTask::jac() const
 	*													VectorOrientationTask
 	*/
 
-VectorOrientationTask::VectorOrientationTask(const rbd::MultiBody &mb, int bodyId,
+VectorOrientationTask::VectorOrientationTask(const rbd::MultiBody &mb,
+	const std::string& bodyName,
 	const Eigen::Vector3d &bodyVector, const Eigen::Vector3d &targetVector) :
 	actualVector_(Eigen::Vector3d::Zero()),
 	bodyVector_(bodyVector),
 	targetVector_(targetVector),
-	bodyIndex_(mb.bodyIndexById(bodyId)),
-	jac_(mb, bodyId),
+	bodyIndex_(mb.bodyIndexByName(bodyName)),
+	jac_(mb, bodyName),
 	eval_(3),
 	speed_(3),
 	normalAcc_(3),

--- a/src/Tasks.h
+++ b/src/Tasks.h
@@ -44,7 +44,8 @@ namespace tasks
 class TASKS_DLLAPI PositionTask
 {
 public:
-	PositionTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Vector3d& pos,
+	PositionTask(const rbd::MultiBody& mb, const std::string& bodyName,
+		const Eigen::Vector3d& pos,
 		const Eigen::Vector3d& bodyPoint=Eigen::Vector3d::Zero());
 
 	void position(const Eigen::Vector3d& pos);
@@ -83,8 +84,10 @@ private:
 class TASKS_DLLAPI OrientationTask
 {
 public:
-	OrientationTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Quaterniond& ori);
-	OrientationTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Matrix3d& ori);
+	OrientationTask(const rbd::MultiBody& mb, const std::string& bodyName,
+			const Eigen::Quaterniond& ori);
+	OrientationTask(const rbd::MultiBody& mb, const std::string& bodyName,
+			const Eigen::Matrix3d& ori);
 
 	void orientation(const Eigen::Quaterniond& ori);
 	void orientation(const Eigen::Matrix3d& ori);
@@ -119,7 +122,7 @@ private:
 class TASKS_DLLAPI TransformTaskCommon
 {
 public:
-	TransformTaskCommon(const rbd::MultiBody& mb, int bodyId,
+	TransformTaskCommon(const rbd::MultiBody& mb, const std::string& bodyName,
 		const sva::PTransformd& X_0_t,
 		const sva::PTransformd& X_b_p);
 
@@ -155,7 +158,7 @@ public:
 	/**
 		* Compute eval, speed, normalAcc and jac in moving 'p' frame.
 		*/
-	SurfaceTransformTask(const rbd::MultiBody& mb, int bodyId,
+	SurfaceTransformTask(const rbd::MultiBody& mb, const std::string& bodyName,
 		const sva::PTransformd& X_0_t,
 		const sva::PTransformd& X_b_p=sva::PTransformd::Identity());
 
@@ -177,7 +180,8 @@ public:
 		* @param E_0_c Optional rotation between the world farme and a user
 		* defined frame 'c' to change the frame of the task.
 		*/
-	TransformTask(const rbd::MultiBody& mb, int bodyId, const sva::PTransformd& X_0_t,
+	TransformTask(const rbd::MultiBody& mb, const std::string& bodyName,
+		const sva::PTransformd& X_0_t,
 		const sva::PTransformd& X_b_p=sva::PTransformd::Identity(),
 		const Eigen::Matrix3d& E_0_c=Eigen::Matrix3d::Identity());
 
@@ -197,7 +201,8 @@ class TASKS_DLLAPI MultiRobotTransformTask
 {
 public:
 	MultiRobotTransformTask(const std::vector<rbd::MultiBody>& mbs,
-		int r1Index, int r2Index, int r1BodyId, int r2BodyId,
+		int r1Index, int r2Index, const std::string& r1BodyName,
+		const std::string& r2BodyName,
 		const sva::PTransformd& X_r1b_r1s, const sva::PTransformd& X_r2b_r2s);
 
 	int r1Index() const;
@@ -237,9 +242,9 @@ private:
 class TASKS_DLLAPI SurfaceOrientationTask
 {
 public:
-	SurfaceOrientationTask(const rbd::MultiBody& mb, int bodyId,
+	SurfaceOrientationTask(const rbd::MultiBody& mb, const std::string& bodyName,
 		const Eigen::Quaterniond& ori, const sva::PTransformd& X_b_s);
-	SurfaceOrientationTask(const rbd::MultiBody& mb, int bodyId,
+	SurfaceOrientationTask(const rbd::MultiBody& mb, const std::string& bodyName,
 		const Eigen::Matrix3d& ori, const sva::PTransformd& X_b_s);
 
 	void orientation(const Eigen::Quaterniond& ori);
@@ -276,10 +281,12 @@ private:
 class TASKS_DLLAPI GazeTask
 {
 public:
-	GazeTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Vector2d &point2d,
+	GazeTask(const rbd::MultiBody& mb, const std::string& bodyName,
+		const Eigen::Vector2d &point2d,
 		double depthEstimate, const sva::PTransformd& X_b_gaze,
 		const Eigen::Vector2d &point2d_ref=Eigen::Vector2d::Zero());
-	GazeTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Vector3d &point3d,
+	GazeTask(const rbd::MultiBody& mb, const std::string& bodyName,
+		const Eigen::Vector3d &point3d,
 		const sva::PTransformd& X_b_gaze,
 		const Eigen::Vector2d &point2d_ref=Eigen::Vector2d::Zero());
 
@@ -319,7 +326,7 @@ private:
 class PositionBasedVisServoTask
 {
 public:
-	PositionBasedVisServoTask(const rbd::MultiBody &mb, int bodyId,
+	PositionBasedVisServoTask(const rbd::MultiBody &mb, const std::string& bodyName,
 		const sva::PTransformd& X_t_s, const sva::PTransformd& X_b_s);
 
 	void error(const sva::PTransformd& X_t_s);
@@ -502,7 +509,8 @@ private:
 class TASKS_DLLAPI LinVelocityTask
 {
 public:
-	LinVelocityTask(const rbd::MultiBody& mb, int bodyId, const Eigen::Vector3d& vel,
+	LinVelocityTask(const rbd::MultiBody& mb, const std::string& bodyName,
+		const Eigen::Vector3d& vel,
 		const Eigen::Vector3d& bodyPoint=Eigen::Vector3d::Zero());
 
 	void velocity(const Eigen::Vector3d& s);
@@ -541,9 +549,9 @@ private:
 class TASKS_DLLAPI OrientationTrackingTask
 {
 public:
-	OrientationTrackingTask(const rbd::MultiBody& mb, int bodyId,
+	OrientationTrackingTask(const rbd::MultiBody& mb, const std::string& bodyName,
 		const Eigen::Vector3d& bodyPoint, const Eigen::Vector3d& bodyAxis,
-		const std::vector<int>& trackingJointsId,
+		const std::vector<std::string>& trackingJointsName,
 		const Eigen::Vector3d& trackedPoint);
 
 	void trackedPoint(const Eigen::Vector3d& tp);
@@ -582,8 +590,8 @@ private:
 class TASKS_DLLAPI RelativeDistTask
 {
 public:
-	//Give information on 1 body (bodyId, r_b1_p, r_0_b2p)
-	typedef std::tuple<int, Eigen::Vector3d, Eigen::Vector3d> rbInfo;
+	//Give information on 1 body (bodyName, r_b1_p, r_0_b2p)
+	typedef std::tuple<std::string, Eigen::Vector3d, Eigen::Vector3d> rbInfo;
 
 public:
 	RelativeDistTask(const rbd::MultiBody& mb, const double timestep,
@@ -635,7 +643,7 @@ private:
 class TASKS_DLLAPI VectorOrientationTask
 {
 public:
-	VectorOrientationTask(const rbd::MultiBody& mb, int bodyId,
+	VectorOrientationTask(const rbd::MultiBody& mb, const std::string& bodyName,
 	const Eigen::Vector3d& bodyVector, const Eigen::Vector3d& targetVector);
 
 	void update(const rbd::MultiBody& mb, const rbd::MultiBodyConfig& mbc,

--- a/tests/QPMultiRobotTest.cpp
+++ b/tests/QPMultiRobotTest.cpp
@@ -84,13 +84,13 @@ BOOST_AUTO_TEST_CASE(TwoArmContactTest)
 	qp::QPSolver solver;
 
 	std::vector<qp::UnilateralContact> contVec =
-		{qp::UnilateralContact(0, 1, 3, 3,
+		{qp::UnilateralContact(0, 1, "b3", "b3",
 			{Vector3d::Zero()}, RotX(cst::pi<double>()/2.), X_b1_b2,
 			3, std::tan(cst::pi<double>()/4.))};
 
 	Matrix3d oriD = RotZ(cst::pi<double>()/4.);
 	Vector3d posD(oriD*mbc2Init.bodyPosW.back().translation());
-	qp::PositionTask posTask(mbs, 1, 3, posD);
+	qp::PositionTask posTask(mbs, 1, "b3", posD);
 	qp::SetPointTask posTaskSp(mbs, 1, &posTask, 1000., 1.);
 
 	qp::ContactAccConstr contCstrAcc;
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(TwoArmContactTest)
 	// Also test OrientationTask on the second robot
 
 	mbcs = {mbc1Init, mbc2Init};
-	qp::OrientationTask oriTask(mbs, 1, 3, oriD);
+	qp::OrientationTask oriTask(mbs, 1, "b3", oriD);
 	qp::SetPointTask oriTaskSp(mbs, 1, &oriTask, 1000., 1.);
 
 	qp::ContactSpeedConstr contCstrSpeed(0.001);
@@ -231,19 +231,19 @@ BOOST_AUTO_TEST_CASE(TwoArmDDynamicContactTest)
 
 	// The fixed robot can pull the other
 	std::vector<qp::UnilateralContact> contVecFail =
-		{qp::UnilateralContact(0, 1, 3, 0,
+		{qp::UnilateralContact(0, 1, "b3", "b0",
 			points, RotX(-cst::pi<double>()/2.), X_b1_b2,
 			nrGen, 0.7)};
 
 	// The fixed robot can push the other
 	std::vector<qp::UnilateralContact> contVec =
-		{qp::UnilateralContact({0, 1, 3, 0},
+		{qp::UnilateralContact({0, 1, "b3", "b0"},
 			points, RotX(cst::pi<double>()/2.), X_b1_b2,
 			nrGen, 0.7)};
 
 	// The fixed robot has non coplanar force apply on the other
 	std::vector<qp::BilateralContact> contVecBi =
-		{qp::BilateralContact({0, 1, 3, 0},
+		{qp::BilateralContact({0, 1, "b3", "b0"},
 			biPoints, biFrames, X_b1_b2,
 			nrGen, 1.)};
 
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(TwoArmMultiCoMTest)
 	const int nrGen = 3;
 	// The fixed robot can push the other
 	std::vector<qp::UnilateralContact> contVec =
-		{qp::UnilateralContact({0, 1, 3, 3},
+		{qp::UnilateralContact({0, 1, "b3", "b3"},
 		 {Vector3d(0.,0.,0.)}, RotX(cst::pi<double>()/2.), X_b1_b2,
 			nrGen, 0.7)};
 
@@ -475,7 +475,7 @@ BOOST_AUTO_TEST_CASE(MultiRobotTransformTest)
 
 	qp::PostureTask posture1Task(mbs, 0, mbc1Init.q, 0.1, 10.);
 	qp::PostureTask posture2Task(mbs, 1, mbc2Init.q, 0.1, 10.);
-	qp::MultiRobotTransformTask mrtt(mbs, 0, 1, 3, 3,
+	qp::MultiRobotTransformTask mrtt(mbs, 0, 1, "b3", "b3",
 		sva::PTransformd(sva::RotZ(-cst::pi<double>()/8.)),
 		sva::PTransformd::Identity(), 100., 1000.);
 	mrtt.dimWeight((Vector6d() << 0., 0., 1., 1., 1.,0.).finished());

--- a/tests/QPSolverTest.cpp
+++ b/tests/QPSolverTest.cpp
@@ -18,7 +18,6 @@
 // includes
 // std
 #include <fstream>
-#include <iostream>
 #include <tuple>
 
 // boost
@@ -120,7 +119,7 @@ BOOST_AUTO_TEST_CASE(QPTaskTest)
 	solver.updateConstrSize();
 
 	Vector3d posD = Vector3d(0.707106, 0.707106, 0.);
-	qp::PositionTask posTask(mbs, 0, 3, posD);
+	qp::PositionTask posTask(mbs, 0, "b3", posD);
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 10., 1.);
 
 	// Test addTask
@@ -145,7 +144,7 @@ BOOST_AUTO_TEST_CASE(QPTaskTest)
 	BOOST_CHECK_EQUAL(solver.nrTasks(), 0);
 
 
-	qp::OrientationTask oriTask(mbs, 0, 3, RotZ(cst::pi<double>()/2.));
+	qp::OrientationTask oriTask(mbs, 0, "b3", RotZ(cst::pi<double>()/2.));
 	qp::SetPointTask oriTaskSp(mbs, 0, &oriTask, 10., 1.);
 
 	// Test addTask
@@ -171,7 +170,7 @@ BOOST_AUTO_TEST_CASE(QPTaskTest)
 
 
 	qp::PostureTask postureTask(mbs, 0, {{}, {0.2}, {0.4}, {-0.8}}, 10., 1.);
-	postureTask.jointsStiffness(mbs, {{2, 10.}});
+	postureTask.jointsStiffness(mbs, {{"j2", 10.}});
 	solver.addTask(&postureTask);
 
 	// Test PostureTask
@@ -212,7 +211,7 @@ BOOST_AUTO_TEST_CASE(QPTaskTest)
 	solver.removeTask(&comTaskSp);
 
 
-	qp::LinVelocityTask linVelocityTask(mbs, 0, 3, -Vector3d::UnitX()*0.005);
+	qp::LinVelocityTask linVelocityTask(mbs, 0, "b3", -Vector3d::UnitX()*0.005);
 	qp::SetPointTask linVelocityTaskSp(mbs, 0, &linVelocityTask, 1000., 10000.);
 
 	solver.addTask(&linVelocityTaskSp);
@@ -263,14 +262,14 @@ BOOST_AUTO_TEST_CASE(QPConstrTest)
 
 
 	std::vector<qp::UnilateralContact> contVec =
-		{qp::UnilateralContact(0, 1, 3, 0, {Vector3d::Zero()}, Matrix3d::Identity(),
+		{qp::UnilateralContact(0, 1, "b3", "b0", {Vector3d::Zero()}, Matrix3d::Identity(),
 		 sva::PTransformd::Identity(), 3, std::tan(cst::pi<double>()/4.))};
 
 	Vector3d posD = Vector3d(0.707106, 0.707106, 0.);
-	qp::PositionTask posTask(mbs, 0, 3, posD);
+	qp::PositionTask posTask(mbs, 0, "b3", posD);
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 10., 1.);
 
-	qp::OrientationTask oriTask(mbs, 0, 3, RotZ(cst::pi<double>()/2.));
+	qp::OrientationTask oriTask(mbs, 0, "b3", RotZ(cst::pi<double>()/2.));
 	qp::SetPointTask oriTaskSp(mbs, 0, &oriTask, 10., 1.);
 
 
@@ -430,7 +429,7 @@ BOOST_AUTO_TEST_CASE(QPConstrTest)
 	// MotionConstr test with contact
 	mbcs[0] = mbcInit;
 	contVec =
-		{qp::UnilateralContact(0, 1, 3, 0, {Vector3d::Zero()}, Matrix3d::Identity(),
+		{qp::UnilateralContact(0, 1, "b3", "b0", {Vector3d::Zero()}, Matrix3d::Identity(),
 		 sva::PTransformd::Identity(), 3, std::tan(cst::pi<double>()/4.))};
 
 	solver.addGenInequalityConstraint(&motionCstr);
@@ -495,8 +494,8 @@ BOOST_AUTO_TEST_CASE(QPJointLimitsTest)
 
 	qp::QPSolver solver;
 
-	int bodyI = mb.bodyIndexById(3);
-	qp::PositionTask posTask(mbs, 0, 3,
+	int bodyI = mb.bodyIndexByName("b3");
+	qp::PositionTask posTask(mbs, 0, "b3",
 		RotZ(cst::pi<double>()/2.)*mbcInit.bodyPosW[bodyI].translation());
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 10., 1.);
 
@@ -576,8 +575,8 @@ BOOST_AUTO_TEST_CASE(QPDamperJointLimitsTest)
 
 	qp::QPSolver solver;
 
-	int bodyI = mb.bodyIndexById(3);
-	qp::PositionTask posTask(mbs, 0, 3,
+	int bodyI = mb.bodyIndexByName("b3");
+	qp::PositionTask posTask(mbs, 0, "b3",
 		RotZ(cst::pi<double>()/2.)*mbcInit.bodyPosW[bodyI].translation());
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 10., 1.);
 
@@ -658,8 +657,8 @@ BOOST_AUTO_TEST_CASE(QPTorqueLimitsTest)
 
 	qp::QPSolver solver;
 
-	int bodyI = mb.bodyIndexById(3);
-	qp::PositionTask posTask(mbs, 0, 3,
+	int bodyI = mb.bodyIndexByName("b3");
+	qp::PositionTask posTask(mbs, 0, "b3",
 		RotZ(cst::pi<double>()/2.)*mbcInit.bodyPosW[bodyI].translation());
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 10., 1.);
 
@@ -815,8 +814,8 @@ BOOST_AUTO_TEST_CASE(QPAutoCollTest)
 
 	qp::QPSolver solver;
 
-	int bodyI = mb.bodyIndexById(3);
-	qp::PositionTask posTask(mbs, 0, 3, mbcInit.bodyPosW[bodyI].translation());
+	int bodyI = mb.bodyIndexByName("b3");
+	qp::PositionTask posTask(mbs, 0, "b3", mbcInit.bodyPosW[bodyI].translation());
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 50., 1.);
 
 	sch::S_Sphere b0(0.25), b3(0.25);
@@ -826,8 +825,8 @@ BOOST_AUTO_TEST_CASE(QPAutoCollTest)
 	qp::CollisionConstr autoCollConstr(mbs, 0.001);
 	int collId1 = 10;
 	autoCollConstr.addCollision(mbs, collId1,
-		0, 0, &b0, I,
-		0, 3, &b3, I,
+		0, "b0", &b0, I,
+		0, "b3", &b3, I,
 		0.01, 0.005, 1.);
 	BOOST_CHECK_EQUAL(autoCollConstr.nrCollisions(), 1);
 
@@ -869,8 +868,8 @@ BOOST_AUTO_TEST_CASE(QPAutoCollTest)
 
 	// test automatic damping computation
 	autoCollConstr.addCollision(mbs, collId1,
-		0, 0, &b0, I,
-		0, 3, &b3, I,
+		0, "b0", &b0, I,
+		0, "b3", &b3, I,
 		0.1, 0.01, 0., 0.1);
 	BOOST_CHECK_EQUAL(autoCollConstr.nrCollisions(), 1);
 	posTask.position(mbcInit.bodyPosW[bodyI].translation());
@@ -935,8 +934,8 @@ BOOST_AUTO_TEST_CASE(QPStaticEnvCollTest)
 
 	qp::QPSolver solver;
 
-	int bodyI = mb.bodyIndexById(3);
-	qp::PositionTask posTask(mbs, 0, 3, mbcInit.bodyPosW[bodyI].translation());
+	int bodyI = mb.bodyIndexByName("b3");
+	qp::PositionTask posTask(mbs, 0, "b3", mbcInit.bodyPosW[bodyI].translation());
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 50., 1.);
 
 	sch::S_Sphere b0(0.25), b3(0.25);
@@ -948,8 +947,8 @@ BOOST_AUTO_TEST_CASE(QPStaticEnvCollTest)
 	qp::CollisionConstr seCollConstr(mbs, 0.001);
 	int collId1 = 10;
 	seCollConstr.addCollision(mbs, collId1,
-		0, 3, &b3, I,
-		1, 0, &b0, I,
+		0, "b3", &b3, I,
+		1, "b0", &b0, I,
 		0.01, 0.005, 1.);
 	BOOST_CHECK_EQUAL(seCollConstr.nrCollisions(), 1);
 
@@ -991,8 +990,8 @@ BOOST_AUTO_TEST_CASE(QPStaticEnvCollTest)
 
 	// test damping computation
 	seCollConstr.addCollision(mbs, collId1,
-		0, 3, &b3, I,
-		1, 0, &b0, I,
+		0, "b3", &b3, I,
+		1, "b0", &b0, I,
 		0.1, 0.01, 0., 0.1);
 	BOOST_CHECK_EQUAL(seCollConstr.nrCollisions(), 1);
 	posTask.position(mbcInit.bodyPosW[bodyI].translation());
@@ -1089,11 +1088,11 @@ BOOST_AUTO_TEST_CASE(QPBilatContactTest)
 		};
 
 	std::vector<qp::UnilateralContact> uni =
-		{qp::UnilateralContact(0, 1, 0, 0,
+		{qp::UnilateralContact(0, 1, "b0", "b0",
 			points, Matrix3d::Identity(), sva::PTransformd::Identity(),
 			3, 0.7)};
 	std::vector<qp::BilateralContact> bi =
-		{qp::BilateralContact(0, 1, 0, 0,
+		{qp::BilateralContact(0, 1, "b0", "b0",
 			points, biFrames, sva::PTransformd::Identity(),
 			3., 0.7)};
 
@@ -1200,11 +1199,11 @@ BOOST_AUTO_TEST_CASE(QPDofContactsTest)
 
 	qp::ContactPosConstr contCstrSpeed(0.005);
 	// target in cf coordinate is transform into world frame
-	qp::PositionTask posTask(mbs, 0, 0,
+	qp::PositionTask posTask(mbs, 0, "b0",
 		(X_b1_cf*mbcInit.bodyPosW[0]).rotation().transpose()*Vector3d(1., 1., -1.));
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 10., 1.);
 	// Rotation in cf coordinate
-	qp::OrientationTask oriTask(mbs, 0, 0,
+	qp::OrientationTask oriTask(mbs, 0, "b0",
 		(X_b1_cf*mbcInit.bodyPosW[0]).rotation().transpose()*sva::RotY(0.1)*sva::RotX(0.5));
 	qp::SetPointTask oriTaskSp(mbs, 0, &oriTask, 10., 1.);
 
@@ -1221,7 +1220,7 @@ BOOST_AUTO_TEST_CASE(QPDofContactsTest)
 
 	sva::PTransformd X_b1_b2(mbcEnv.bodyPosW[0]*mbcInit.bodyPosW[0].inv());
 	std::vector<qp::UnilateralContact> uni =
-		{qp::UnilateralContact(0, 1, 0, 0,
+		{qp::UnilateralContact(0, 1, "b0", "b0",
 			points, Matrix3d::Identity(), X_b1_b2,
 			3, 0.7, X_b1_cf)};
 
@@ -1235,7 +1234,7 @@ BOOST_AUTO_TEST_CASE(QPDofContactsTest)
 	contactDof(4, 4) = 1.;
 
 	// test Z free
-	contCstrSpeed.addDofContact({0, 1, 0, 0}, contactDof);
+	contCstrSpeed.addDofContact({0, 1, "b0", "b0"}, contactDof);
 	solver.nrVars(mbs, uni, {});
 	solver.updateConstrSize();
 
@@ -1264,7 +1263,7 @@ BOOST_AUTO_TEST_CASE(QPDofContactsTest)
 	contactDof(3, 3) = 1.;
 	contactDof(4, 5) = 1.;
 	contCstrSpeed.resetDofContacts();
-	contCstrSpeed.addDofContact({0, 1, 0, 0}, contactDof);
+	contCstrSpeed.addDofContact({0, 1, "b0", "b0"}, contactDof);
 	contCstrSpeed.updateDofContacts();
 	mbcs[0] = mbcInit;
 	for(int i = 0; i < 100; ++i)
@@ -1291,7 +1290,7 @@ BOOST_AUTO_TEST_CASE(QPDofContactsTest)
 	contactDof(3, 4) = 1.;
 	contactDof(4, 5) = 1.;
 	contCstrSpeed.resetDofContacts();
-	contCstrSpeed.addDofContact({0, 1, 0, 0}, contactDof);
+	contCstrSpeed.addDofContact({0, 1, "b0", "b0"}, contactDof);
 	contCstrSpeed.updateDofContacts();
 
 	// add the orientation task in cf coordinate
@@ -1337,13 +1336,13 @@ BOOST_AUTO_TEST_CASE(QPBoundedSpeedTest)
 	qp::QPSolver solver;
 	solver.solver("QLD");
 
-	int bodyId = 3;
-	int bodyIndex = mb.bodyIndexById(bodyId);
+	std::string bodyName("b3");
+	int bodyIndex = mb.bodyIndexByName(bodyName);
 	sva::PTransformd bodyPoint(Vector3d(0., 0.1, 0.));
 
 	qp::BoundedSpeedConstr constSpeed(mbs, 0, 0.005);
 	qp::PostureTask postureTask(mbs, 0, {{}, {0.}, {0.}, {0.}}, 1., 0.01);
-	qp::PositionTask posTask(mbs, 0, bodyId, Vector3d(1., -1., 1.), bodyPoint.translation());
+	qp::PositionTask posTask(mbs, 0, bodyName, Vector3d(1., -1., 1.), bodyPoint.translation());
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 20., 1.);
 	MatrixXd dof(1, 6);
 	VectorXd speed(1);
@@ -1351,7 +1350,7 @@ BOOST_AUTO_TEST_CASE(QPBoundedSpeedTest)
 	// X body axis must have 0 velocity
 	dof << 0.,0.,0.,1.,0.,0.;
 	speed << 0.;
-	constSpeed.addBoundedSpeed(mbs, bodyId, bodyPoint.translation(), dof, speed);
+	constSpeed.addBoundedSpeed(mbs, bodyName, bodyPoint.translation(), dof, speed);
 	BOOST_CHECK_EQUAL(constSpeed.nrBoundedSpeeds(), 1);
 
 	constSpeed.addToSolver(solver);
@@ -1380,7 +1379,7 @@ BOOST_AUTO_TEST_CASE(QPBoundedSpeedTest)
 
 
 	// same test but with Z axis
-	BOOST_CHECK(constSpeed.removeBoundedSpeed(bodyId));
+	BOOST_CHECK(constSpeed.removeBoundedSpeed(bodyName));
 	constSpeed.updateBoundedSpeeds();
 	BOOST_CHECK_EQUAL(constSpeed.nrBoundedSpeeds(), 0);
 	BOOST_CHECK_EQUAL(constSpeed.maxGenInEq(), 0);
@@ -1388,7 +1387,7 @@ BOOST_AUTO_TEST_CASE(QPBoundedSpeedTest)
 	// must resize constraint matrix since nrMaxIneq has changed
 	solver.updateConstrSize();
 	dof << 0.,0.,0.,0.,0.,1.;
-	constSpeed.addBoundedSpeed(mbs, bodyId, bodyPoint.translation(), dof, speed);
+	constSpeed.addBoundedSpeed(mbs, bodyName, bodyPoint.translation(), dof, speed);
 	constSpeed.updateBoundedSpeeds();
 	BOOST_CHECK_EQUAL(constSpeed.nrBoundedSpeeds(), 1);
 	BOOST_CHECK_EQUAL(constSpeed.maxGenInEq(), 1);
@@ -1475,7 +1474,7 @@ BOOST_AUTO_TEST_CASE(SurfaceOrientationTask)
 	solver.nrVars(mbs, {}, {});
 	solver.updateConstrSize();
 
-	qp::SurfaceOrientationTask surfOriTask(mbs, 0, 3,
+	qp::SurfaceOrientationTask surfOriTask(mbs, 0, "b3",
 		RotZ(cst::pi<double>()/2.), sva::PTransformd(Vector3d(0., 0., 0.)));
 	qp::SetPointTask surfOriTaskSp(mbs, 0, &surfOriTask, 10., 1.);
 
@@ -1509,9 +1508,9 @@ BOOST_AUTO_TEST_CASE(QPCoMPlaneTest)
 
 	qp::QPSolver solver;
 
-	int bodyI = mb.bodyIndexById(3);
+	int bodyI = mb.bodyIndexByName("b3");
 	Eigen::Vector3d initPos(mbcInit.bodyPosW[bodyI].translation());
-	qp::PositionTask posTask(mbs, 0, 3, initPos);
+	qp::PositionTask posTask(mbs, 0, "b3", initPos);
 	qp::SetPointTask posTaskSp(mbs, 0, &posTask, 50., 1.);
 	Eigen::Vector3d n1(0., 0., -1.);
 	Eigen::Vector3d n2(0., 0., 1.);
@@ -1609,10 +1608,10 @@ BOOST_AUTO_TEST_CASE(JointsSelector)
 
 	qp::QPSolver solver;
 
-	qp::PositionTask pt(mbs, 0, 3, Vector3d::Zero());
+	qp::PositionTask pt(mbs, 0, "b3", Vector3d::Zero());
 	// construct two JointSelector that should have the same joints
-	qp::JointsSelector js1(qp::JointsSelector::ActiveJoints(mbs, 0, &pt, {2, 1}));
-	qp::JointsSelector js2(qp::JointsSelector::UnactiveJoints(mbs, 0, &pt, {0, -1}));
+	qp::JointsSelector js1(qp::JointsSelector::ActiveJoints(mbs, 0, &pt, {"j2", "j1"}));
+	qp::JointsSelector js2(qp::JointsSelector::UnactiveJoints(mbs, 0, &pt, {"j0", "Root"}));
 	qp::SetPointTask js1Sp(mbs, 0, &js1, 1., 1.);
 	qp::SetPointTask js2Sp(mbs, 0, &js2, 1., 1.);
 
@@ -1686,7 +1685,7 @@ BOOST_AUTO_TEST_CASE(QPTransformTaskTest)
 		Vector3d::Random());
 	Quaterniond E_0_c(Vector4d::Random().normalized());
 
-	qp::TransformTask transTask(mbs, 0, 3, X_0_t, X_b_s, E_0_c.matrix());
+	qp::TransformTask transTask(mbs, 0, "b3", X_0_t, X_b_s, E_0_c.matrix());
 	VectorXd dimW(6);
 	dimW << 1., 1., 1., 1., 1., 1.;
 	qp::SetPointTask transTaskSp(mbs, 0, &transTask, 10., dimW, 100.);
@@ -1717,7 +1716,7 @@ BOOST_AUTO_TEST_CASE(QPTransformTaskTest)
 
 
 	// Test SurfaceTransformTask
-	qp::SurfaceTransformTask surfTransTask(mbs, 0, 3, X_0_t, X_b_s);
+	qp::SurfaceTransformTask surfTransTask(mbs, 0, "b3", X_0_t, X_b_s);
 	qp::SetPointTask surfTransTaskSp(mbs, 0, &surfTransTask, 10., dimW, 100.);
 	solver.addTask(&surfTransTaskSp);
 	solver.updateTasksNrVars(mbs);

--- a/tests/TasksTest.cpp
+++ b/tests/TasksTest.cpp
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(PositionTaskTest)
 
 	std::tie(mb, mbc) = makeZXZArm();
 
-	tasks::PositionTask pt(mb, 3, Vector3d::Random(), Vector3d::Random());
+	tasks::PositionTask pt(mb, "b3", Vector3d::Random(), Vector3d::Random());
 
 	testTaskNumDiff(mb, mbc, pt, ClassicUpdater<tasks::PositionTask>(),
 		PosTester());
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(OrientationTaskTest)
 
 	std::tie(mb, mbc) = makeZXZArm();
 
-	tasks::OrientationTask ot(mb, 3, Quaterniond(Vector4d::Random().normalized()));
+	tasks::OrientationTask ot(mb, "b3", Quaterniond(Vector4d::Random().normalized()));
 
 	testTaskNumDiff(mb, mbc, ot, ClassicUpdater<tasks::OrientationTask>(),
 		OriTaskTester());
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(TransformTaskTest)
 		Vector3d::Random());
 	Eigen::Quaterniond E_0_c(Vector4d::Random().normalized());
 
-	tasks::TransformTask tt(mb, 3, X_0_t, X_b_s, E_0_c.matrix());
+	tasks::TransformTask tt(mb, "b3", X_0_t, X_b_s, E_0_c.matrix());
 
 	testTaskNumDiff(mb, mbc, tt,
 		NormalAccUpdater<tasks::TransformTask>(mb), PosTTTester(), 100);
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(SurfaceTransformTaskTest)
 	sva::PTransformd X_0_t(Quaterniond(Vector4d::Random().normalized()),
 		Vector3d::Random());
 
-	tasks::SurfaceTransformTask tt(mb, 3, X_0_t, X_b_s);
+	tasks::SurfaceTransformTask tt(mb, "b3", X_0_t, X_b_s);
 
 	testTaskNumDiff(mb, mbc, tt,
 		NormalAccUpdater<tasks::SurfaceTransformTask>(mb), PosMRTTTester(), 100);
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(MultiRobotTransformTaskTest)
 	sva::PTransformd X_r2b_r2s(Quaterniond(Vector4d::Random().normalized()),
 		Vector3d::Random());
 
-	tasks::MultiRobotTransformTask mrtt(mbs, 0, 1, 3, 3, X_r1b_r1s, X_r2b_r2s);
+	tasks::MultiRobotTransformTask mrtt(mbs, 0, 1, "b3", "b3", X_r1b_r1s, X_r2b_r2s);
 
 	testTaskNumDiff(mbs, mbcs, mrtt,
 		MRNormalAccUpdater<tasks::MultiRobotTransformTask>(mbs, 6), PosMRTTTester());
@@ -502,7 +502,7 @@ BOOST_AUTO_TEST_CASE(SurfaceOrientationTaskTest)
 
 	std::tie(mb, mbc) = makeZXZArm();
 
-	tasks::SurfaceOrientationTask sot(mb, 3,
+	tasks::SurfaceOrientationTask sot(mb, "b3",
 		Quaterniond(Vector4d::Random().normalized()),
 		sva::PTransformd(Quaterniond(Vector4d::Random().normalized()), Vector3d::Random()));
 
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(LinVelocityTaskTest)
 
 	std::tie(mb, mbc) = makeZXZArm();
 
-	tasks::LinVelocityTask lvt(mb, 3, Vector3d::Random());
+	tasks::LinVelocityTask lvt(mb, "b3", Vector3d::Random());
 
 	testTaskNumDiff(mb, mbc, lvt, ClassicUpdater<tasks::LinVelocityTask>(),
 		VelTester());
@@ -604,7 +604,7 @@ BOOST_AUTO_TEST_CASE(VectorOrientationTaskTest)
 
 	std::tie(mb, mbc) = makeZXZArm();
 
-	tasks::VectorOrientationTask vot(mb, 3, Vector3d::Random(), Vector3d::Random());
+	tasks::VectorOrientationTask vot(mb, "b3", Vector3d::Random(), Vector3d::Random());
 
 	testTaskNumDiff(mb, mbc, vot, NormalAccUpdater<tasks::VectorOrientationTask>(mb),
 		VectOriTester());

--- a/tests/arms.h
+++ b/tests/arms.h
@@ -45,19 +45,19 @@ makeZXZArm(bool isFixed=true,
 
 	RBInertiad rbi(mass, h, I);
 
-	Body b0(rbi, 0, "b0");
-	Body b1(rbi, 1, "b1");
-	Body b2(rbi, 2, "b2");
-	Body b3(rbi, 3, "b3");
+	Body b0(rbi, "b0");
+	Body b1(rbi, "b1");
+	Body b2(rbi, "b2");
+	Body b3(rbi, "b3");
 
 	mbg.addBody(b0);
 	mbg.addBody(b1);
 	mbg.addBody(b2);
 	mbg.addBody(b3);
 
-	Joint j0(Joint::RevZ, true, 0, "j0");
-	Joint j1(Joint::RevX, true, 1, "j1");
-	Joint j2(Joint::RevZ, true, 2, "j2");
+	Joint j0(Joint::RevZ, true, "j0");
+	Joint j1(Joint::RevX, true, "j1");
+	Joint j2(Joint::RevZ, true, "j2");
 
 	mbg.addJoint(j0);
 	mbg.addJoint(j1);
@@ -72,11 +72,11 @@ makeZXZArm(bool isFixed=true,
 	PTransformd from(Vector3d(0., 0., 0.));
 
 
-	mbg.linkBodies(0, PTransformd::Identity(), 1, from, 0);
-	mbg.linkBodies(1, to, 2, from, 1);
-	mbg.linkBodies(2, to, 3, from, 2);
+	mbg.linkBodies("b0", PTransformd::Identity(), "b1", from, "j0");
+	mbg.linkBodies("b1", to, "b2", from, "j1");
+	mbg.linkBodies("b2", to, "b3", from, "j2");
 
-	MultiBody mb = mbg.makeMultiBody(0, isFixed, X_base);
+	MultiBody mb = mbg.makeMultiBody("b0", isFixed, X_base);
 
 	MultiBodyConfig mbc(mb);
 	mbc.zero(mb);
@@ -100,11 +100,11 @@ std::tuple<rbd::MultiBody, rbd::MultiBodyConfig> makeEnv()
 
 	RBInertiad rbi(mass, h, I);
 
-	Body b0(rbi, 0, "b0");
+	Body b0(rbi, "b0");
 
 	mbg.addBody(b0);
 
-	MultiBody mb = mbg.makeMultiBody(0, true);
+	MultiBody mb = mbg.makeMultiBody("b0", true);
 
 	MultiBodyConfig mbc(mb);
 	mbc.zero(mb);


### PR DESCRIPTION
This is a follow up to the [switch to textual id in RBDyn](https://github.com/jrl-umi3218/RBDyn/pull/1)

~~This is still a work in progress:~~
- [x] Tasks take name in constructor
- [x] Contacts ID only have names as properties
- [x] Constraints correctly use names to build jacobians
- [x] Tests
- [x] Python bindings