### PR TITLE
Correct a bug introduced by 4cea9aa

### DIFF
--- a/src/QPMotionConstr.h
+++ b/src/QPMotionConstr.h
@@ -116,7 +116,7 @@ protected:
 			const std::vector<FrictionCone>& cones);
 
 
-		std::string bodyIndex;
+		int bodyIndex;
 		int lambdaBegin;
 		rbd::Jacobian jac;
 		std::vector<Eigen::Vector3d> points;


### PR DESCRIPTION
An index was incorrectly made a std::string.

This did not seem to produce any bugs, as bodyIndex was never used in QPMotionConstr. We could probably remove this field entirely, but I guess it was in the distant past.