### PR TITLE
Topic/mimic joint

### DIFF
--- a/src/GenQPSolver.cpp
+++ b/src/GenQPSolver.cpp
@@ -65,6 +65,29 @@ GenQPSolver* createQPSolver(const std::string& name)
 	return qpFactory.at(name)();
 }
 
+void GenQPSolver::setDependencies(int nrVars, std::vector<std::tuple<int, int, double>> dependencies)
+{
+	dependencies_ = dependencies;
+	fullToReduced_.resize(nrVars, -1);
+	reducedToFull_.resize(nrVars - static_cast<int>(dependencies_.size()), -1);
+	/* Retrieve the variables which are removed due to the dependencies */
+	std::vector<int> removedVars; removedVars.reserve(dependencies.size() + 1);
+	for(const auto & d : dependencies)
+	{
+		removedVars.push_back(std::get<1>(d));
+	}
+	/* Prevent issue once we have gone past the last removed variable */
+	removedVars.push_back(nrVars);
+	std::sort(removedVars.begin(), removedVars.end());
+	/* Number of removed variables encountered so far */
+	size_t shift = 0;
+	for(size_t i = 0; i < fullToReduced_.size(); ++i)
+	{
+		if(i == static_cast<size_t>(removedVars[shift])) { shift++; continue; }
+		fullToReduced_[i] = static_cast<int>(i - shift);
+		reducedToFull_[i-shift] = static_cast<int>(i);
+	}
+}
 
 } // namespace qp
 

--- a/src/GenQPSolver.h
+++ b/src/GenQPSolver.h
@@ -83,18 +83,10 @@ public:
 
 	/**
 	* Setup dependent variables, only linear dependency are supported
-	* @param fullToReduced A full to reduced variables vector
-	* @param reducedToFull A reduced to full variables vector
+	* @param nrVars Variable number.
 	* @param dependencies List of tuple {primary, replica, factor}
 	*/
-	virtual void setReductionParameters(std::vector<int> fullToReduced,
-																			std::vector<int> reducedToFull,
-																			std::vector<std::tuple<int, int, double>> dependencies)
-	{
-		fullToReduced_ = fullToReduced;
-		reducedToFull_ = reducedToFull;
-		dependencies_ = dependencies;
-	}
+	virtual void setDependencies(int nrVars, std::vector<std::tuple<int, int, double>> dependencies);
 
 	/**
 		* Construct the QP matrices.
@@ -128,8 +120,14 @@ public:
 		const std::vector<Bound*>& boundConstr,
 		std::ostream& out) const = 0;
 protected:
+	/** Correspondance between full variable indices and reduced variables */
 	std::vector<int> fullToReduced_;
+	/** Correspondance between reduced variable indices and full variable indices */
 	std::vector<int> reducedToFull_;
+
+	/** Variable dependencies, each tuple gives the primary variable index in the
+	 * full variable, replica variable index in the full variable and the factor
+	 * in the dependency equation: replica = factor * primary */
 	std::vector<std::tuple<int, int, double>> dependencies_;
 };
 

--- a/src/GenQPSolver.h
+++ b/src/GenQPSolver.h
@@ -83,16 +83,16 @@ public:
 
 	/**
 	* Setup dependent variables, only linear dependency are supported
-	* @param full_to_reduced A full to reduced variables vector
-	* @param reduced_to_full A reduced to full variables vector
+	* @param fullToReduced A full to reduced variables vector
+	* @param reducedToFull A reduced to full variables vector
 	* @param dependencies List of tuple {primary, replica, factor}
 	*/
-	virtual void setReductionParameters(std::vector<int> full_to_reduced,
-																			std::vector<int> reduced_to_full,
+	virtual void setReductionParameters(std::vector<int> fullToReduced,
+																			std::vector<int> reducedToFull,
 																			std::vector<std::tuple<int, int, double>> dependencies)
 	{
-		full_to_reduced_ = full_to_reduced;
-		reduced_to_full_ = reduced_to_full;
+		fullToReduced_ = fullToReduced;
+		reducedToFull_ = reducedToFull;
 		dependencies_ = dependencies;
 	}
 
@@ -128,8 +128,8 @@ public:
 		const std::vector<Bound*>& boundConstr,
 		std::ostream& out) const = 0;
 protected:
-	std::vector<int> full_to_reduced_;
-	std::vector<int> reduced_to_full_;
+	std::vector<int> fullToReduced_;
+	std::vector<int> reducedToFull_;
 	std::vector<std::tuple<int, int, double>> dependencies_;
 };
 

--- a/src/GenQPSolver.h
+++ b/src/GenQPSolver.h
@@ -82,6 +82,21 @@ public:
 	virtual void updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq) = 0;
 
 	/**
+	* Setup dependent variables, only linear dependency are supported
+	* @param full_to_reduced A full to reduced variables vector
+	* @param reduced_to_full A reduced to full variables vector
+	* @param dependencies List of tuple {primary, replica, factor}
+	*/
+	virtual void setReductionParameters(std::vector<int> full_to_reduced,
+																			std::vector<int> reduced_to_full,
+																			std::vector<std::tuple<int, int, double>> dependencies)
+	{
+		full_to_reduced_ = full_to_reduced;
+		reduced_to_full_ = reduced_to_full;
+		dependencies_ = dependencies;
+	}
+
+	/**
 		* Construct the QP matrices.
 		* @param tasks Build \f$ Q \f$ and \f$ c \f$.
 		* @param eqConstr Build \f$ A x = b \f$ constraints.
@@ -112,6 +127,10 @@ public:
 		const std::vector<GenInequality*>& genInEqConstr,
 		const std::vector<Bound*>& boundConstr,
 		std::ostream& out) const = 0;
+protected:
+	std::vector<int> full_to_reduced_;
+	std::vector<int> reduced_to_full_;
+	std::vector<std::tuple<int, int, double>> dependencies_;
 };
 
 

--- a/src/GenQPSolver.h
+++ b/src/GenQPSolver.h
@@ -82,7 +82,7 @@ public:
 	virtual void updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq) = 0;
 
 	/**
-	* Setup dependent variables, only linear dependency are supported
+	* Setup dependent variables, only linear dependencies are supported
 	* @param nrVars Variable number.
 	* @param dependencies List of tuple {primary, replica, factor}
 	*/
@@ -120,9 +120,9 @@ public:
 		const std::vector<Bound*>& boundConstr,
 		std::ostream& out) const = 0;
 protected:
-	/** Correspondance between full variable indices and reduced variables */
+	/** Correspondence between full variable indices and reduced variables */
 	std::vector<int> fullToReduced_;
-	/** Correspondance between reduced variable indices and full variable indices */
+	/** Correspondence between reduced variable indices and full variable indices */
 	std::vector<int> reducedToFull_;
 
 	/** Variable dependencies, each tuple gives the primary variable index in the

--- a/src/GenQPUtils.h
+++ b/src/GenQPUtils.h
@@ -349,15 +349,18 @@ inline void reduceBound(const Eigen::VectorXd & XLFull,
 		const int & primaryReducedI = fullToReduced[primaryFullI];
 		const int & replicaFullI = std::get<1>(d);
 		const double & alpha = std::get<2>(d);
-		if(alpha < 0)
+		if(alpha != 0)
 		{
-			XL(primaryReducedI) = std::max(XL(primaryReducedI), XUFull(replicaFullI)/alpha);
-			XU(primaryReducedI) = std::min(XU(primaryReducedI), XLFull(replicaFullI)/alpha);
-		}
-		else
-		{
-			XL(primaryReducedI) = std::max(XL(primaryReducedI), XLFull(replicaFullI)/alpha);
-			XU(primaryReducedI) = std::min(XU(primaryReducedI), XUFull(replicaFullI)/alpha);
+			if(alpha < 0)
+			{
+				XL(primaryReducedI) = std::max(XL(primaryReducedI), XUFull(replicaFullI)/alpha);
+				XU(primaryReducedI) = std::min(XU(primaryReducedI), XLFull(replicaFullI)/alpha);
+			}
+			else
+			{
+				XL(primaryReducedI) = std::max(XL(primaryReducedI), XLFull(replicaFullI)/alpha);
+				XU(primaryReducedI) = std::min(XU(primaryReducedI), XUFull(replicaFullI)/alpha);
+			}
 		}
 	}
 }

--- a/src/GenQPUtils.h
+++ b/src/GenQPUtils.h
@@ -87,7 +87,7 @@ inline void reduceQC(const Eigen::MatrixXd & QFull, const Eigen::VectorXd & CFul
 	/* Start by moving the non-reduced variables to their new location */
 	for(size_t i = 0; i < reducedToFull.size(); ++i)
 	{
-		for(size_t j = 0; j < reducedToFull.size(); ++j)
+		for(size_t j = i; j < reducedToFull.size(); ++j)
 		{
 			Q(i,j) = QFull(reducedToFull[i], reducedToFull[j]);
 		}
@@ -106,11 +106,12 @@ inline void reduceQC(const Eigen::MatrixXd & QFull, const Eigen::VectorXd & CFul
 		for(size_t i = 0; i < reducedToFull.size(); ++i)
 		{
 			Q(i, primaryReducedI) += alpha*QFull(reducedToFull[i], replicaFullI);
-			Q(primaryReducedI, i) += alpha*QFull(replicaFullI, reducedToFull[i]);
 		}
 		/* Add diagonal element to Q */
 		Q(primaryReducedI, primaryReducedI) += alpha*alpha*QFull(replicaFullI, replicaFullI);
 	}
+	/* Update the lower triangular part of Q */
+	Q = Q.selfadjointView<Eigen::Upper>();
 }
 
 // general qp form

--- a/src/GenQPUtils.h
+++ b/src/GenQPUtils.h
@@ -99,7 +99,7 @@ inline void reduceQC(const Eigen::MatrixXd & QFull, const Eigen::VectorXd & CFul
 		const int & primaryFullI = std::get<0>(d);
 		const int & primaryReducedI = fullToReduced[primaryFullI];
 		const int & replicaFullI = std::get<1>(d);
-		const double & alpha = 1/std::get<2>(d);
+		const double & alpha = std::get<2>(d);
 		/* Apply reduction to C */
 		C(primaryReducedI) += alpha*CFull(replicaFullI);
 		/* Add cross-terms to Q */
@@ -313,12 +313,9 @@ inline void reduceA(const Eigen::MatrixXd & AFull,
 										const std::vector<int> & reducedToFull,
 										const std::vector<std::tuple<int, int, double>> & dependencies)
 {
-	for(size_t i = 0; i < static_cast<size_t>(AFull.rows()); ++i)
+	for(size_t i = 0; i <reducedToFull.size(); ++i)
 	{
-		for(size_t j = 0; j <reducedToFull.size(); ++j)
-		{
-			A(i,j) = AFull(i, reducedToFull[j]);
-		}
+		A.col(i) = AFull.col(reducedToFull[i]);
 	}
 	for(const auto & d : dependencies)
 	{
@@ -326,10 +323,7 @@ inline void reduceA(const Eigen::MatrixXd & AFull,
 		const int & primaryReducedI = fullToReduced[primaryFullI];
 		const int & replicaFullI = std::get<1>(d);
 		const double & alpha = std::get<2>(d);
-		for(int i = 0; i < A.rows(); ++i)
-		{
-			A(i, primaryReducedI) += alpha*AFull(i, replicaFullI);
-		}
+		A.col(primaryReducedI) += alpha*AFull.col(replicaFullI);
 	}
 }
 

--- a/src/GenQPUtils.h
+++ b/src/GenQPUtils.h
@@ -351,6 +351,7 @@ inline void reduceBound(const Eigen::VectorXd & XLFull,
 		const double & alpha = std::get<2>(d);
 		if(alpha != 0)
 		{
+			/** If alpha is negative, the upper/lower bounds should be inverted */
 			if(alpha < 0)
 			{
 				XL(primaryReducedI) = std::max(XL(primaryReducedI), XUFull(replicaFullI)/alpha);

--- a/src/LSSOLQPSolver.h
+++ b/src/LSSOLQPSolver.h
@@ -62,21 +62,21 @@ private:
 	Eigen::MatrixXd A_;
 	Eigen::VectorXd AL_, AU_;
 
-	Eigen::MatrixXd A_full_;
+	Eigen::MatrixXd AFull_;
 
 	Eigen::VectorXd XL_;
 	Eigen::VectorXd XU_;
 
-	Eigen::VectorXd XL_full_;
-	Eigen::VectorXd XU_full_;
+	Eigen::VectorXd XLFull_;
+	Eigen::VectorXd XUFull_;
 
 	Eigen::MatrixXd Q_;
 	Eigen::VectorXd C_;
 
-	Eigen::MatrixXd Q_full_;
-	Eigen::VectorXd C_full_;
+	Eigen::MatrixXd QFull_;
+	Eigen::VectorXd CFull_;
 
-	Eigen::VectorXd X_full_;
+	Eigen::VectorXd XFull_;
 
 	int nrALines_;
 };

--- a/src/LSSOLQPSolver.h
+++ b/src/LSSOLQPSolver.h
@@ -40,14 +40,14 @@ class TASKS_DLLAPI LSSOLQPSolver : public GenQPSolver
 public:
 	LSSOLQPSolver();
 
-	virtual void updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq);
+	virtual void updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq) override;
 	virtual void updateMatrix(const std::vector<Task*>& tasks,
 		const std::vector<Equality*>& eqConstr,
 		const std::vector<Inequality*>& inEqConstr,
 		const std::vector<GenInequality*>& genInEqConstr,
-		const std::vector<Bound*>& boundConstr);
-	virtual bool solve();
-	virtual const Eigen::VectorXd& result() const;
+		const std::vector<Bound*>& boundConstr) override;
+	virtual bool solve() override;
+	virtual const Eigen::VectorXd& result() const override;
 	virtual std::ostream& errorMsg(const std::vector<rbd::MultiBody>& mbs,
 		const std::vector<Task*>& tasks,
 		const std::vector<Equality*>& eqConstr,
@@ -62,11 +62,21 @@ private:
 	Eigen::MatrixXd A_;
 	Eigen::VectorXd AL_, AU_;
 
+	Eigen::MatrixXd A_full_;
+
 	Eigen::VectorXd XL_;
 	Eigen::VectorXd XU_;
 
+	Eigen::VectorXd XL_full_;
+	Eigen::VectorXd XU_full_;
+
 	Eigen::MatrixXd Q_;
 	Eigen::VectorXd C_;
+
+	Eigen::MatrixXd Q_full_;
+	Eigen::VectorXd C_full_;
+
+	Eigen::VectorXd X_full_;
 
 	int nrALines_;
 };

--- a/src/QLDQPSolver.cpp
+++ b/src/QLDQPSolver.cpp
@@ -78,10 +78,6 @@ void QLDQPSolver::updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq)
 		XFull_.resize(nrVars);
 
 		qld_.problem(reducedNrVars, maxAeqLines, maxAineqLines);
-		std::cout << "(before) nrVars " << nrVars << std::endl;
-		std::cout << "nrVars " << reducedNrVars << std::endl;
-		std::cout << "maxAeqLines " << maxAeqLines << std::endl;
-		std::cout << "maxAineqLines " << maxAineqLines << std::endl;
 	}
 	else
 	{

--- a/src/QLDQPSolver.cpp
+++ b/src/QLDQPSolver.cpp
@@ -35,8 +35,11 @@ QLDQPSolver::QLDQPSolver():
 	qld_(),
 	Aeq_(),Aineq_(),
 	beq_(), bineq_(),
+	Aeq_full_(),Aineq_full_(),
 	XL_(),XU_(),
+	XL_full_(),XU_full_(),
 	Q_(),C_(),
+	Q_full_(),C_full_(),
 	nrAeqLines_(0), nrAineqLines_(0)
 {
 }
@@ -47,19 +50,44 @@ void QLDQPSolver::updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq)
 	int maxAeqLines = nrEq;
 	int maxAineqLines = nrInEq + nrGenInEq*2;
 
-	Aeq_.resize(maxAeqLines, nrVars);
-	Aineq_.resize(maxAineqLines, nrVars);
+	Aeq_full_.resize(maxAeqLines, nrVars);
+	Aineq_full_.resize(maxAineqLines, nrVars);
 
 	beq_.resize(maxAeqLines);
 	bineq_.resize(maxAineqLines);
 
-	XL_.resize(nrVars);
-	XU_.resize(nrVars);
+	XL_full_.resize(nrVars);
+	XU_full_.resize(nrVars);
 
-	Q_.resize(nrVars, nrVars);
-	C_.resize(nrVars);
+	Q_full_.resize(nrVars, nrVars);
+	C_full_.resize(nrVars);
 
-	qld_.problem(nrVars, maxAeqLines, maxAineqLines);
+	if(dependencies_.size())
+	{
+		int reducedNrVars = nrVars - static_cast<int>(dependencies_.size());
+
+		Aeq_.resize(maxAeqLines, reducedNrVars);
+		Aineq_.resize(maxAineqLines, reducedNrVars);
+
+		XL_.resize(reducedNrVars);
+		XU_.resize(reducedNrVars);
+
+		Q_.resize(reducedNrVars, reducedNrVars);
+		C_.resize(reducedNrVars);
+
+		X_full_.resize(nrVars);
+
+		qld_.problem(reducedNrVars, maxAeqLines, maxAineqLines);
+		std::cout << "(before) nrVars " << nrVars << std::endl;
+		std::cout << "nrVars " << reducedNrVars << std::endl;
+		std::cout << "maxAeqLines " << maxAeqLines << std::endl;
+		std::cout << "maxAineqLines " << maxAineqLines << std::endl;
+	}
+	else
+	{
+		qld_.problem(nrVars, maxAeqLines, maxAineqLines);
+	}
+
 }
 
 
@@ -70,41 +98,75 @@ void QLDQPSolver::updateMatrix(
 	const std::vector<GenInequality*>& genInEqConstr,
 	const std::vector<Bound*>& boundConstr)
 {
-	Aeq_.setZero();
-	Aineq_.setZero();
+	Aeq_full_.setZero();
+	Aineq_full_.setZero();
 	beq_.setZero();
 	bineq_.setZero();
-	XL_.fill(-std::numeric_limits<double>::infinity());
-	XU_.fill(std::numeric_limits<double>::infinity());
-	Q_.setZero();
-	C_.setZero();
+	XL_full_.fill(-std::numeric_limits<double>::infinity());
+	XU_full_.fill(std::numeric_limits<double>::infinity());
+	Q_full_.setZero();
+	C_full_.setZero();
 
-	const int nrVars = int(Q_.rows());
+	const int nrVars = int(Q_full_.rows());
 
 	nrAeqLines_ = 0;
-	nrAeqLines_ = fillEq(eqConstr, nrVars, nrAeqLines_, Aeq_, beq_);
+	nrAeqLines_ = fillEq(eqConstr, nrVars, nrAeqLines_, Aeq_full_, beq_);
 	nrAineqLines_ = 0;
-	nrAineqLines_ = fillInEq(inEqConstr, nrVars, nrAineqLines_, Aineq_, bineq_);
-	nrAineqLines_ = fillGenInEq(genInEqConstr, nrVars, nrAineqLines_, Aineq_, bineq_);
+	nrAineqLines_ = fillInEq(inEqConstr, nrVars, nrAineqLines_, Aineq_full_, bineq_);
+	nrAineqLines_ = fillGenInEq(genInEqConstr, nrVars, nrAineqLines_, Aineq_full_, bineq_);
 
-	fillBound(boundConstr, XL_, XU_);
-	fillQC(tasks, nrVars, Q_, C_);
+	fillBound(boundConstr, XL_full_, XU_full_);
+	fillQC(tasks, nrVars, Q_full_, C_full_);
+	if(dependencies_.size())
+	{
+		Aeq_.setZero();
+		Aineq_.setZero();
+		XL_.fill(-std::numeric_limits<double>::infinity());
+		XU_.fill(std::numeric_limits<double>::infinity());
+		Q_.setZero();
+		C_.setZero();
+		reduceA(Aeq_full_, Aeq_, full_to_reduced_, reduced_to_full_, dependencies_);
+		reduceA(Aineq_full_, Aineq_, full_to_reduced_, reduced_to_full_, dependencies_);
+		reduceBound(XL_full_, XL_, XU_full_, XU_, full_to_reduced_, reduced_to_full_, dependencies_);
+		reduceQC(Q_full_, C_full_, Q_, C_, full_to_reduced_, reduced_to_full_, dependencies_);
+	}
 }
 
 
 bool QLDQPSolver::solve()
 {
-	bool success = qld_.solve(Q_, C_,
-		Aeq_.block(0, 0, nrAeqLines_, int(Aeq_.cols())), beq_.segment(0, nrAeqLines_),
-		Aineq_.block(0, 0, nrAineqLines_, int(Aineq_.cols())), bineq_.segment(0, nrAineqLines_),
-		XL_, XU_, 1e-6);
+	bool success = false;
+	if(dependencies_.size())
+	{
+		success = qld_.solve(Q_, C_,
+			Aeq_.block(0, 0, nrAeqLines_, int(Aeq_.cols())), beq_.segment(0, nrAeqLines_),
+			Aineq_.block(0, 0, nrAineqLines_, int(Aineq_.cols())), bineq_.segment(0, nrAineqLines_),
+			XL_, XU_, 1e-6);
+		expandResult(qld_.result(), X_full_,
+								 reduced_to_full_,
+								 dependencies_);
+	}
+	else
+	{
+		success = qld_.solve(Q_full_, C_full_,
+			Aeq_full_.block(0, 0, nrAeqLines_, int(Aeq_full_.cols())), beq_.segment(0, nrAeqLines_),
+			Aineq_full_.block(0, 0, nrAineqLines_, int(Aineq_full_.cols())), bineq_.segment(0, nrAineqLines_),
+			XL_full_, XU_full_, 1e-6);
+	}
 	return success;
 }
 
 
 const Eigen::VectorXd& QLDQPSolver::result() const
 {
-	return qld_.result();
+	if(dependencies_.size())
+	{
+		return X_full_;
+	}
+	else
+	{
+		return qld_.result();
+	}
 }
 
 

--- a/src/QLDQPSolver.h
+++ b/src/QLDQPSolver.h
@@ -40,14 +40,14 @@ class TASKS_DLLAPI QLDQPSolver : public GenQPSolver
 public:
 	QLDQPSolver();
 
-	virtual void updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq);
+	virtual void updateSize(int nrVars, int nrEq, int nrInEq, int nrGenInEq) override;
 	virtual void updateMatrix(const std::vector<Task*>& tasks,
 		const std::vector<Equality*>& eqConstr,
 		const std::vector<Inequality*>& inEqConstr,
 		const std::vector<GenInequality*>& genInEqConstr,
-		const std::vector<Bound*>& boundConstr);
-	virtual bool solve();
-	virtual const Eigen::VectorXd& result() const;
+		const std::vector<Bound*>& boundConstr) override;
+	virtual bool solve() override;
+	virtual const Eigen::VectorXd& result() const override;
 	virtual std::ostream& errorMsg(const std::vector<rbd::MultiBody>& mbs,
 		const std::vector<Task*>& tasks,
 		const std::vector<Equality*>& eqConstr,
@@ -62,11 +62,21 @@ private:
 	Eigen::MatrixXd Aeq_, Aineq_;
 	Eigen::VectorXd beq_, bineq_;
 
+	Eigen::MatrixXd Aeq_full_, Aineq_full_;
+
 	Eigen::VectorXd XL_;
 	Eigen::VectorXd XU_;
 
+	Eigen::VectorXd XL_full_;
+	Eigen::VectorXd XU_full_;
+
 	Eigen::MatrixXd Q_;
 	Eigen::VectorXd C_;
+
+	Eigen::MatrixXd Q_full_;
+	Eigen::VectorXd C_full_;
+
+	Eigen::VectorXd X_full_;
 
 	int nrAeqLines_;
 	int nrAineqLines_;

--- a/src/QLDQPSolver.h
+++ b/src/QLDQPSolver.h
@@ -62,21 +62,21 @@ private:
 	Eigen::MatrixXd Aeq_, Aineq_;
 	Eigen::VectorXd beq_, bineq_;
 
-	Eigen::MatrixXd Aeq_full_, Aineq_full_;
+	Eigen::MatrixXd AeqFull_, AineqFull_;
 
 	Eigen::VectorXd XL_;
 	Eigen::VectorXd XU_;
 
-	Eigen::VectorXd XL_full_;
-	Eigen::VectorXd XU_full_;
+	Eigen::VectorXd XLFull_;
+	Eigen::VectorXd XUFull_;
 
 	Eigen::MatrixXd Q_;
 	Eigen::VectorXd C_;
 
-	Eigen::MatrixXd Q_full_;
-	Eigen::VectorXd C_full_;
+	Eigen::MatrixXd QFull_;
+	Eigen::VectorXd CFull_;
 
-	Eigen::VectorXd X_full_;
+	Eigen::VectorXd XFull_;
 
 	int nrAeqLines_;
 	int nrAineqLines_;

--- a/src/QPConstr.cpp
+++ b/src/QPConstr.cpp
@@ -292,7 +292,6 @@ double DamperJointLimitsConstr::computeDamper(double dist,
 	return damping*((dist - sDist)/(iDist - sDist));
 }
 
-
 /**
 	*													CollisionConstr
 	*/
@@ -638,8 +637,8 @@ double CollisionConstr::computeDamping(const std::vector<rbd::MultiBody>& mbs,
 CoMIncPlaneConstr::PlaneData::PlaneData(
 	int planeId, const Eigen::Vector3d& normal, double offset,
 	double di, double ds, double damping, double dampOff,
-        const Eigen::Vector3d& speed,
-        const Eigen::Vector3d& normalDot):
+	const Eigen::Vector3d& speed,
+	const Eigen::Vector3d& normalDot):
 		normal(normal),
 		normalDot(normalDot),
 		offset(offset),
@@ -677,14 +676,14 @@ void CoMIncPlaneConstr::addPlane(int planeId,
 {
 	dataVec_.emplace_back(planeId, normal, offset,
 		di, ds, damping, dampingOff, Eigen::Vector3d::Zero(),
-                Eigen::Vector3d::Zero());
+		Eigen::Vector3d::Zero());
 	activated_.reserve(dataVec_.size());
 }
 
 void CoMIncPlaneConstr::addPlane(int planeId,
 	const Eigen::Vector3d& normal, double offset,
 	double di, double ds, double damping,
-        const Eigen::Vector3d& speed, const Eigen::Vector3d& normalDot, double dampingOff)
+	const Eigen::Vector3d& speed, const Eigen::Vector3d& normalDot, double dampingOff)
 {
 	dataVec_.emplace_back(planeId, normal, offset,
 		di, ds, damping, dampingOff, speed, normalDot);
@@ -1429,7 +1428,7 @@ void ImageConstr::update(const std::vector<rbd::MultiBody>& mbs,
 			if((constrDirection_==1.) || ((point2d_[iOther] > (*iDistMin_)[iOther]) && (point2d_[iOther] < (*iDistMax_)[iOther])))
 			{
 				if((constrDirection_*point2d_[i] < constrDirection_*(*iDistMin_)[i]) //check min
-					 && ((constrDirection_==1.) || (point2d_[i] < 0.))) //handle occlusion constraint ambiquity
+						&& ((constrDirection_==1.) || (point2d_[i] < 0.))) //handle occlusion constraint ambiquity
 				{
 					if(constrDirection_*point2d_  [i] > constrDirection_*(*sDistMin_)[i])
 					{

--- a/src/QPConstr.h
+++ b/src/QPConstr.h
@@ -203,8 +203,6 @@ private:
 	double damperOff_;
 };
 
-
-
 /**
 	* Avoid that too robot links enter into collision based on a velocity damper.
 	* For each collision pair:

--- a/src/QPSolver.cpp
+++ b/src/QPSolver.cpp
@@ -224,29 +224,7 @@ void QPSolver::nrVars(const std::vector<rbd::MultiBody>& mbs,
 		c->updateNrVars(mbs, data_);
 	}
 
-	if(dependencies.size())
-	{
-		std::vector<int> fullToReduced(data_.nrVars_, -1);
-		std::vector<int> reducedToFull(data_.nrVars_ - static_cast<int>(dependencies.size()), -1);
-		std::vector<int> removedVars; removedVars.reserve(dependencies.size() + 1);
-		for(const auto & d : dependencies)
-		{
-			removedVars.push_back(std::get<1>(d));
-		}
-		removedVars.push_back(data_.nrVars_);
-		std::sort(removedVars.begin(), removedVars.end());
-		size_t shift = 0;
-		for(size_t i = 0; i < fullToReduced.size(); ++i)
-		{
-			if(i == static_cast<size_t>(removedVars[shift])) { shift++; continue; }
-			fullToReduced[i] = static_cast<int>(i - shift);
-			reducedToFull[i-shift] = static_cast<int>(i);
-		}
-		solver_->setReductionParameters(std::move(fullToReduced),
-																		std::move(reducedToFull),
-																		std::move(dependencies));
-	}
-
+	solver_->setDependencies(data_.nrVars_, dependencies);
 	solver_->updateSize(data_.nrVars_, maxEqLines_, maxInEqLines_, maxGenInEqLines_);
 }
 

--- a/src/QPSolver.cpp
+++ b/src/QPSolver.cpp
@@ -226,8 +226,8 @@ void QPSolver::nrVars(const std::vector<rbd::MultiBody>& mbs,
 
 	if(dependencies.size())
 	{
-		std::vector<int> full_to_reduced(data_.nrVars_, -1);
-		std::vector<int> reduced_to_full(data_.nrVars_ - static_cast<int>(dependencies.size()), -1);
+		std::vector<int> fullToReduced(data_.nrVars_, -1);
+		std::vector<int> reducedToFull(data_.nrVars_ - static_cast<int>(dependencies.size()), -1);
 		std::vector<int> removedVars; removedVars.reserve(dependencies.size() + 1);
 		for(const auto & d : dependencies)
 		{
@@ -236,14 +236,14 @@ void QPSolver::nrVars(const std::vector<rbd::MultiBody>& mbs,
 		removedVars.push_back(data_.nrVars_);
 		std::sort(removedVars.begin(), removedVars.end());
 		size_t shift = 0;
-		for(size_t i = 0; i < full_to_reduced.size(); ++i)
+		for(size_t i = 0; i < fullToReduced.size(); ++i)
 		{
-			if(i == removedVars[shift]) { shift++; continue; }
-			full_to_reduced[i] = i - shift;
-			reduced_to_full[i-shift] = i;
+			if(i == static_cast<size_t>(removedVars[shift])) { shift++; continue; }
+			fullToReduced[i] = static_cast<int>(i - shift);
+			reducedToFull[i-shift] = static_cast<int>(i);
 		}
-		solver_->setReductionParameters(std::move(full_to_reduced),
-																		std::move(reduced_to_full),
+		solver_->setReductionParameters(std::move(fullToReduced),
+																		std::move(reducedToFull),
 																		std::move(dependencies));
 	}
 

--- a/src/QPSolver.cpp
+++ b/src/QPSolver.cpp
@@ -163,11 +163,11 @@ void QPSolver::nrVars(const std::vector<rbd::MultiBody>& mbs,
 			data_.mobileRobotIndex_.push_back(int(r));
 			for(const auto & j : mb.joints())
 			{
-				if(j.is_mimic())
+				if(j.isMimic())
 				{
-					dependencies.emplace_back(data_.alphaDBegin_[r] + mb.jointPosInDof(mb.jointIndexByName(j.mimic_name())),
+					dependencies.emplace_back(data_.alphaDBegin_[r] + mb.jointPosInDof(mb.jointIndexByName(j.mimicName())),
 																		data_.alphaDBegin_[r] + mb.jointPosInDof(mb.jointIndexByName(j.name())),
-																		j.mimic_multiplier());
+																		j.mimicMultiplier());
 				}
 			}
 		}

--- a/tests/QPSolverTest.cpp
+++ b/tests/QPSolverTest.cpp
@@ -681,7 +681,7 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 
 	MultiBodyConfig mbcInit(mb);
 	mbcInit.zero(mb);
-	BOOST_CHECK_EQUAL(mbcInit.q[2][0], 0.5);
+	BOOST_CHECK_EQUAL(mbcInit.q[3][0], 0.5);
 
 	forwardKinematics(mb, mbcInit);
 	forwardVelocity(mb, mbcInit);
@@ -710,7 +710,7 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 		forwardKinematics(mbs[0], mbcs[0]);
 		forwardVelocity(mbs[0], mbcs[0]);
 		BOOST_REQUIRE(mbcs[0].q[1][0] == -mbcs[0].q[2][0]);
-		BOOST_REQUIRE(mbcs[0].q[2][0] == 0.5);
+		BOOST_REQUIRE(mbcs[0].q[3][0] == 0.5);
 	}
 	BOOST_CHECK_SMALL(mbcs[0].q[1][0], 1e-4);
 
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 		forwardKinematics(mbs[0], mbcs[0]);
 		forwardVelocity(mbs[0], mbcs[0]);
 		BOOST_REQUIRE(mbcs[0].q[1][0] == -mbcs[0].q[2][0]);
-		BOOST_REQUIRE(mbcs[0].q[2][0] == 0.5);
+		BOOST_REQUIRE(mbcs[0].q[3][0] == 0.5);
 	}
 	BOOST_CHECK_SMALL(mbcs[0].q[1][0] - 0.2, 1e-4);
 

--- a/tests/QPSolverTest.cpp
+++ b/tests/QPSolverTest.cpp
@@ -75,8 +75,8 @@ BOOST_AUTO_TEST_CASE(FrictionConeTest)
 
 	Matrix3d rep;
 	rep << 0., 1., 0.,
-				 0., 0., 1.,
-				 1., 0., 0.;
+					0., 0., 1.,
+					1., 0., 0.;
 	qp::FrictionCone cone2(rep, 4, mu);
 	for(Vector3d v: cone2.generators)
 	{
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(QPConstrTest)
 
 	std::vector<qp::UnilateralContact> contVec =
 		{qp::UnilateralContact(0, 1, "b3", "b0", {Vector3d::Zero()}, Matrix3d::Identity(),
-		 sva::PTransformd::Identity(), 3, std::tan(cst::pi<double>()/4.))};
+			sva::PTransformd::Identity(), 3, std::tan(cst::pi<double>()/4.))};
 
 	Vector3d posD = Vector3d(0.707106, 0.707106, 0.);
 	qp::PositionTask posTask(mbs, 0, "b3", posD);
@@ -430,7 +430,7 @@ BOOST_AUTO_TEST_CASE(QPConstrTest)
 	mbcs[0] = mbcInit;
 	contVec =
 		{qp::UnilateralContact(0, 1, "b3", "b0", {Vector3d::Zero()}, Matrix3d::Identity(),
-		 sva::PTransformd::Identity(), 3, std::tan(cst::pi<double>()/4.))};
+			sva::PTransformd::Identity(), 3, std::tan(cst::pi<double>()/4.))};
 
 	solver.addGenInequalityConstraint(&motionCstr);
 	BOOST_CHECK_EQUAL(solver.nrGenInequalityConstraints(), 1);
@@ -634,6 +634,94 @@ BOOST_AUTO_TEST_CASE(QPDamperJointLimitsTest)
 	BOOST_CHECK_EQUAL(solver.nrConstraints(), 0);
 }
 
+BOOST_AUTO_TEST_CASE(QPMimicJointTest)
+{
+	using namespace Eigen;
+	using namespace sva;
+	using namespace rbd;
+	using namespace tasks;
+	namespace cst = boost::math::constants;
+
+	/* Make a very simple gripper */
+	MultiBodyGraph mbg;
+
+	double mass = 1.;
+	Matrix3d I = Matrix3d::Identity();
+	Vector3d h = Vector3d::Zero();
+
+	RBInertiad rbi(mass, h, I);
+
+	Body b0(rbi, "b0");
+	Body b1(rbi, "b1");
+	Body b2(rbi, "b2");
+
+	mbg.addBody(b0);
+	mbg.addBody(b1);
+	mbg.addBody(b2);
+
+	Joint j0(Joint::RevZ, true, "j0");
+	Joint j1(Joint::RevZ, true, "j1");
+	j1.set_mimic("j0", -1.0, 0.0);
+
+	mbg.addJoint(j0);
+	mbg.addJoint(j1);
+
+	PTransformd from = sva::PTransformd::Identity();
+
+	mbg.linkBodies("b0", from, "b1", from, "j0");
+	mbg.linkBodies("b1", from, "b2", from, "j1");
+
+	MultiBody mb = mbg.makeMultiBody("b0", true, from);
+
+	MultiBodyConfig mbcInit(mb);
+	mbcInit.zero(mb);
+
+	forwardKinematics(mb, mbcInit);
+	forwardVelocity(mb, mbcInit);
+
+	std::vector<rbd::MultiBody> mbs = {mb};
+	std::vector<rbd::MultiBodyConfig> mbcs = {mbcInit};
+
+	qp::QPSolver solver;
+
+	tasks::qp::PostureTask pt(mbs, 0, mbcInit.q, 100.0, 10.0);
+
+	solver.nrVars(mbs, {}, {});
+	solver.updateConstrSize();
+
+	solver.addTask(&pt);
+	BOOST_CHECK_EQUAL(solver.nrTasks(), 1);
+
+
+	// Test mimic joint in mbc
+	mbcs[0] = mbcInit;
+	for(int i = 0; i < 1000; ++i)
+	{
+		BOOST_REQUIRE(solver.solve(mbs, mbcs));
+		eulerIntegration(mbs[0], mbcs[0], 0.001);
+
+		forwardKinematics(mbs[0], mbcs[0]);
+		forwardVelocity(mbs[0], mbcs[0]);
+		BOOST_REQUIRE(mbcs[0].q[1][0] == -mbcs[0].q[2][0]);
+	}
+	BOOST_CHECK_SMALL(mbcs[0].q[1][0], 1e-4);
+
+	mbcs[0] = mbcInit;
+	pt.posture({{}, {0.2}, {-0.2}});
+	for(int i = 0; i < 1000; ++i)
+	{
+		BOOST_REQUIRE(solver.solve(mbs, mbcs));
+		eulerIntegration(mbs[0], mbcs[0], 0.001);
+
+		forwardKinematics(mbs[0], mbcs[0]);
+		forwardVelocity(mbs[0], mbcs[0]);
+		BOOST_REQUIRE(mbcs[0].q[1][0] == -mbcs[0].q[2][0]);
+	}
+	BOOST_CHECK_SMALL(mbcs[0].q[1][0] - 0.2, 1e-4);
+
+	solver.removeTask(&pt);
+	BOOST_CHECK_EQUAL(solver.nrTasks(), 0);
+}
 
 
 BOOST_AUTO_TEST_CASE(QPTorqueLimitsTest)
@@ -1074,7 +1162,7 @@ BOOST_AUTO_TEST_CASE(QPBilatContactTest)
 	std::vector<Eigen::Vector3d> points =
 		{
 			Vector3d(0.1, 0.1, 0.),
-			 Vector3d(-0.1, 0.1, 0.),
+			Vector3d(-0.1, 0.1, 0.),
 			Vector3d(-0.1, -0.1, 0.),
 			Vector3d(0.1, -0.1, 0.)
 		};
@@ -1213,7 +1301,7 @@ BOOST_AUTO_TEST_CASE(QPDofContactsTest)
 	std::vector<Eigen::Vector3d> points =
 		{
 			Vector3d(0.1, 0.1, 0.),
-			 Vector3d(-0.1, 0.1, 0.),
+			Vector3d(-0.1, 0.1, 0.),
 			Vector3d(-0.1, -0.1, 0.),
 			Vector3d(0.1, -0.1, 0.)
 		};

--- a/tests/QPSolverTest.cpp
+++ b/tests/QPSolverTest.cpp
@@ -654,27 +654,34 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 	Body b0(rbi, "b0");
 	Body b1(rbi, "b1");
 	Body b2(rbi, "b2");
+	Body b3(rbi, "b3");
 
 	mbg.addBody(b0);
 	mbg.addBody(b1);
 	mbg.addBody(b2);
+	mbg.addBody(b3);
 
 	Joint j0(Joint::RevZ, true, "j0");
 	Joint j1(Joint::RevZ, true, "j1");
 	j1.makeMimic("j0", -1.0, 0.0);
+	Joint j2(Joint::RevZ, true, "j2");
+	j2.makeMimic("j0", 0.0, 0.5);
 
 	mbg.addJoint(j0);
 	mbg.addJoint(j1);
+	mbg.addJoint(j2);
 
 	PTransformd from = sva::PTransformd::Identity();
 
 	mbg.linkBodies("b0", from, "b1", from, "j0");
 	mbg.linkBodies("b1", from, "b2", from, "j1");
+	mbg.linkBodies("b2", from, "b3", from, "j2");
 
 	MultiBody mb = mbg.makeMultiBody("b0", true, from);
 
 	MultiBodyConfig mbcInit(mb);
 	mbcInit.zero(mb);
+	BOOST_CHECK_EQUAL(mbcInit.q[2][0], 0.5);
 
 	forwardKinematics(mb, mbcInit);
 	forwardVelocity(mb, mbcInit);
@@ -703,11 +710,12 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 		forwardKinematics(mbs[0], mbcs[0]);
 		forwardVelocity(mbs[0], mbcs[0]);
 		BOOST_REQUIRE(mbcs[0].q[1][0] == -mbcs[0].q[2][0]);
+		BOOST_REQUIRE(mbcs[0].q[2][0] == 0.5);
 	}
 	BOOST_CHECK_SMALL(mbcs[0].q[1][0], 1e-4);
 
 	mbcs[0] = mbcInit;
-	pt.posture({{}, {0.2}, {-0.2}});
+	pt.posture({{}, {0.2}, {-0.2}, {0.5}});
 	for(int i = 0; i < 1000; ++i)
 	{
 		BOOST_REQUIRE(solver.solve(mbs, mbcs));
@@ -716,6 +724,7 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 		forwardKinematics(mbs[0], mbcs[0]);
 		forwardVelocity(mbs[0], mbcs[0]);
 		BOOST_REQUIRE(mbcs[0].q[1][0] == -mbcs[0].q[2][0]);
+		BOOST_REQUIRE(mbcs[0].q[2][0] == 0.5);
 	}
 	BOOST_CHECK_SMALL(mbcs[0].q[1][0] - 0.2, 1e-4);
 

--- a/tests/QPSolverTest.cpp
+++ b/tests/QPSolverTest.cpp
@@ -661,7 +661,7 @@ BOOST_AUTO_TEST_CASE(QPMimicJointTest)
 
 	Joint j0(Joint::RevZ, true, "j0");
 	Joint j1(Joint::RevZ, true, "j1");
-	j1.set_mimic("j0", -1.0, 0.0);
+	j1.makeMimic("j0", -1.0, 0.0);
 
 	mbg.addJoint(j0);
 	mbg.addJoint(j1);


### PR DESCRIPTION
This PR adds a simple constraint for mimic joints. It imposes that the selected joint and the mimiced joint keep the same configuration.

I am not sure that's the best way to do it so I'd welcome alternate solutions. Ideally, we would probably want the "mimicing" joint configuration to be the same variable as the mimiced one but within the current framework I don't think this is a possibility.