### PR TITLE
Allow to set dimensional gains on TrajectoryTask

### DIFF
--- a/src/Tasks/QPTasks.h
+++ b/src/Tasks/QPTasks.h
@@ -150,23 +150,25 @@ public:
 		const Eigen::VectorXd& dimWeight, double weight);
 
 	void setGains(double gainPos, double gainVel);
+	void setGains(const Eigen::VectorXd & stiffness, const Eigen::VectorXd & damping);
 	void stiffness(double gainPos);
-	double stiffness() const;
+	void stiffness(const Eigen::VectorXd & stiffness);
+	const Eigen::VectorXd & stiffness() const;
 	void damping(double gainVel);
-	double damping() const;
-
+	void damping(const Eigen::VectorXd & damping);
+	const Eigen::VectorXd & damping() const;
 
 	void refVel(const Eigen::VectorXd& refVel);
 	const Eigen::VectorXd & refVel() const;
 	void refAccel(const Eigen::VectorXd& refAccel);
 	const Eigen::VectorXd & refAccel() const;
 
-	virtual void update(const std::vector<rbd::MultiBody>& mbs,
+	void update(const std::vector<rbd::MultiBody>& mbs,
 		const std::vector<rbd::MultiBodyConfig>& mbcs,
 		const SolverData& data) override;
 
 private:
-	double gainPos_, gainVel_;
+	Eigen::VectorXd stiffness_, damping_;
 	Eigen::VectorXd refVel_, refAccel_;
 };
 


### PR DESCRIPTION
This PR changes the stiffness and damping gains in `tasks::qp::TrajectoryTask` to allow to set different gains on different dimensions.

- The single-value setters are kept and will simply set all dimensional gains to the same value
- The single-value getters are removed