### PR TITLE
improve packaging

### DIFF
--- a/.github/workflows/Tasks.recipe
+++ b/.github/workflows/Tasks.recipe
@@ -1,3 +1,0 @@
-# git-build-recipe format 0.4 deb-version {debversion}+{time}+{git-commit}
-https://github.com/jrl-umi3218/Tasks @REF@
-run git submodule update --init

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: CI of Tasks
 
 on:
   push:
+    paths-ignore:
+      # Changes to those files don't mandate running CI
+      - ".github/workflows/package.yml"
+      - "debian/**"
     branches:
       - '**'
   pull_request:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,6 +15,11 @@ name: Package Tasks
 
 on:
   push:
+    paths-ignore:
+      # Changes to those files don't mandate rebuilding a package
+      - "doc/**"
+      - "README.md"
+      - ".github/workflows/build.yml"
     branches:
       - master
     tags:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -74,30 +74,28 @@ jobs:
       matrix:
         dist: [xenial, bionic, focal]
         arch: [i386, amd64]
+        exclude:
+          - dist: focal
+            arch: i386
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - name: Prepare recipe
+      with:
+        submodules: recursive
+    - name: Choose extra mirror
       run: |
-        set -x
-        cp .github/workflows/Tasks.recipe /tmp/Tasks.recipe
         export REF=`echo ${{ github.ref }} | sed -e 's@refs/[a-z]*/@@'`
-        sed -i "s#@REF@#${REF}#" /tmp/Tasks.recipe
         if [ $REF == "master" ]
         then
           echo "::set-env name=EXTRA_MIRROR::https://dl.bintray.com/gergondet/multi-contact-head"
         else
           echo "::set-env name=EXTRA_MIRROR::https://dl.bintray.com/gergondet/multi-contact-release"
         fi
-        echo "Prepared recipe"
-        echo "###############"
-        cat /tmp/Tasks.recipe
     - name: Build package
-      uses: jrl-umi3218/github-actions/build-package@master
+      uses: jrl-umi3218/github-actions/build-package-native@master
       with:
         dist: ${{ matrix.dist }}
         arch: ${{ matrix.arch }}
-        recipe: /tmp/Tasks.recipe
         other-mirrors: ${{ env.EXTRA_MIRROR }}
         other-gpg-keys: "0x892EA6EE273707C6495A6FB6220D644C64666806"
     - uses: actions/upload-artifact@v1
@@ -113,6 +111,9 @@ jobs:
       matrix:
         dist: [xenial, bionic, focal]
         arch: [i386, amd64]
+        exclude:
+          - dist: focal
+            arch: i386
     runs-on: ubuntu-18.04
     steps:
     - name: Set upload parameters

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,10 @@ endif()
 add_project_dependency(RBDyn REQUIRED)
 add_project_dependency(sch-core REQUIRED)
 add_project_dependency(eigen-qld REQUIRED)
-add_project_dependency(eigen-lssol QUIET)
+find_package(eigen-lssol QUIET)
+if(${eigen-lssol_FOUND})
+  add_project_dependency(eigen-lssol REQUIRED)
+endif()
 
 # For MSVC, set local environment variable to enable finding the built dll
 # of the main library when launching ctest with RUN_TESTS

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
- Use a native container rather than through cowbuilder to speed-up package build time (cuts around 5 minutes of setup time)
- Don't make `eigen-lssol` a project dependency if it not found when we build the project, down the line this avoids issue with CMake 3.15 and up where we use `find_dependency` in the generated config script