### PR TITLE
Minor compilation fixes for gcc 4.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: recursive
+    - name: Cleanup windows environment
+      shell: bash
+      run: |
+        set -x
+        rm -rf /c/hostedtoolcache/windows/Boost/1.72.0/lib/cmake/Boost-1.72.0
+      if: matrix.os == 'windows-latest'
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:

--- a/src/LSSOLQPSolver.cpp
+++ b/src/LSSOLQPSolver.cpp
@@ -98,14 +98,15 @@ bool LSSOLQPSolver::solve()
   bool success = false;
   if(dependencies_.size())
   {
-    success = lssol_.solve(XL_, XU_, Q_, C_, A_.block(0, 0, nrALines_, A_.cols()), AL_.segment(0, nrALines_),
-                           AU_.segment(0, nrALines_));
+    success = lssol_.solve(XL_, XU_, static_cast<Eigen::LSSOLBase::RefMat>(Q_), C_,
+                           A_.block(0, 0, nrALines_, A_.cols()), AL_.segment(0, nrALines_), AU_.segment(0, nrALines_));
     expandResult(lssol_.result(), XFull_, reducedToFull_, dependencies_);
   }
   else
   {
-    success = lssol_.solve(XLFull_, XUFull_, QFull_, CFull_, AFull_.block(0, 0, nrALines_, AFull_.cols()),
-                           AL_.segment(0, nrALines_), AU_.segment(0, nrALines_));
+    success = lssol_.solve(XLFull_, XUFull_, static_cast<Eigen::LSSOLBase::RefMat>(QFull_), CFull_,
+                           AFull_.block(0, 0, nrALines_, AFull_.cols()), AL_.segment(0, nrALines_),
+                           AU_.segment(0, nrALines_));
   }
   return success;
 }

--- a/src/Tasks/QPConstr.h
+++ b/src/Tasks/QPConstr.h
@@ -323,10 +323,7 @@ private:
     CollData(CollData &&) = default;
     CollData(const CollData &) = delete;
     CollData & operator=(const CollData &) = delete;
-    CollData & operator=(const CollData &&)
-    {
-      return *this;
-    }
+    CollData & operator=(CollData &&) = default;
 
     std::unique_ptr<sch::CD_Pair> pair;
     Eigen::Vector3d normVecDist;

--- a/src/Tasks/QPConstr.h
+++ b/src/Tasks/QPConstr.h
@@ -320,6 +320,14 @@ private:
              double ds,
              double damping,
              double dampingOff);
+    CollData(CollData &&) = default;
+    CollData(const CollData &) = delete;
+    CollData & operator=(const CollData &) = delete;
+    CollData & operator=(const CollData &&)
+    {
+      return *this;
+    }
+
     std::unique_ptr<sch::CD_Pair> pair;
     Eigen::Vector3d normVecDist;
     double di, ds;


### PR DESCRIPTION
This MR adds some minor modifications to allow compiling with GCC 4.7 on Debian (on the HRP2 robot).