### PR TITLE
[CoMTask] Expose computed CoM

### DIFF
--- a/src/Tasks.cpp
+++ b/src/Tasks.cpp
@@ -887,9 +887,14 @@ void CoMTask::com(const Eigen::Vector3d & com)
   com_ = com;
 }
 
-const Eigen::Vector3d CoMTask::com() const
+const Eigen::Vector3d & CoMTask::com() const
 {
   return com_;
+}
+
+const Eigen::Vector3d & CoMTask::actual() const
+{
+  return actual_;
 }
 
 void CoMTask::updateInertialParameters(const rbd::MultiBody & mb)
@@ -899,7 +904,8 @@ void CoMTask::updateInertialParameters(const rbd::MultiBody & mb)
 
 void CoMTask::update(const rbd::MultiBody & mb, const rbd::MultiBodyConfig & mbc)
 {
-  eval_ = com_ - rbd::computeCoM(mb, mbc);
+  actual_ = rbd::computeCoM(mb, mbc);
+  eval_ = com_ - actual_;
 
   speed_ = jac_.velocity(mb, mbc);
   normalAcc_ = jac_.normalAcceleration(mb, mbc);
@@ -911,6 +917,7 @@ void CoMTask::update(const rbd::MultiBody & mb,
                      const Eigen::Vector3d & com,
                      const std::vector<sva::MotionVecd> & normalAccB)
 {
+  actual_ = com;
   eval_ = com_ - com;
 
   speed_ = jac_.velocity(mb, mbc);

--- a/src/Tasks/QPTasks.h
+++ b/src/Tasks/QPTasks.h
@@ -868,9 +868,14 @@ public:
     ct_.com(com);
   }
 
-  const Eigen::Vector3d com() const
+  const Eigen::Vector3d & com() const
   {
     return ct_.com();
+  }
+
+  const Eigen::Vector3d & actual() const
+  {
+    return ct_.actual();
   }
 
   void updateInertialParameters(const std::vector<rbd::MultiBody> & mbs);

--- a/src/Tasks/Tasks.h
+++ b/src/Tasks/Tasks.h
@@ -400,7 +400,8 @@ public:
   CoMTask(const rbd::MultiBody & mb, const Eigen::Vector3d & com, std::vector<double> weight);
 
   void com(const Eigen::Vector3d & com);
-  const Eigen::Vector3d com() const;
+  const Eigen::Vector3d & com() const;
+  const Eigen::Vector3d & actual() const;
 
   void updateInertialParameters(const rbd::MultiBody & mb);
 
@@ -420,6 +421,7 @@ public:
 
 private:
   Eigen::Vector3d com_;
+  Eigen::Vector3d actual_;
   rbd::CoMJacobian jac_;
 
   Eigen::VectorXd eval_;


### PR DESCRIPTION
- Exposes the `CoM` position computed within the `CoMTask`
- Returns the `CoM` target by const reference instead of value