### PR TITLE
Account for allowed changes in X_b1_b2 in contact constraint

### DIFF
--- a/src/QPContactConstr.cpp
+++ b/src/QPContactConstr.cpp
@@ -91,6 +91,27 @@ std::set<ContactConstrCommon::ContactCommon> ContactConstrCommon::contactCommonI
  *															ContactConstr
  */
 
+void ContactConstr::ContactData::update(const std::vector<rbd::MultiBodyConfig> & mbcs)
+{
+  if(contacts.size() != 2 && contacts[0].sign > 0)
+  {
+    // X_b1_b2 is only encoded in the constraint if there is two active robots or if the active robot is second
+    return;
+  }
+  auto & X_b2_cf = contacts.size() == 2 ? contacts[1].X_b_p : contacts[0].X_b_p;
+  const auto & mbc1 = mbcs[r1Index];
+  const auto & X_0_b1 = mbc1.bodyPosW[b1Index];
+  const auto & mbc2 = mbcs[r2Index];
+  const auto & X_0_b2 = mbc2.bodyPosW[b2Index];
+  auto X_b1_b2_current = X_0_b2 * X_0_b1.inv();
+  auto X_b2_cf_current = X_b1_cf * X_b1_b2_current.inv();
+  // Only apply the motion allowed by the DoF selection
+  auto error = revDof * sva::transformError(X_b2_cf_current.inv(), X_b2_cf.inv()).vector();
+  auto offset = sva::PTransformd(sva::RotX(error(0)) * sva::RotY(error(1)) * sva::RotZ(error(2)),
+                                 Eigen::Vector3d(error(3), error(4), error(5)));
+  X_b2_cf = offset * X_b2_cf;
+}
+
 ContactConstr::ContactConstr() : cont_(), fullJac_(), dofJac_(), A_(), b_(), nrEq_(0), totalAlphaD_(0) {}
 
 void ContactConstr::updateDofContacts()
@@ -134,14 +155,16 @@ void ContactConstr::updateNrVars(const std::vector<rbd::MultiBody> & mbs, const 
       if(mbs[rIndex].nrDof() > 0)
       {
         contacts.emplace_back(rIndex, data.alphaDBegin(rIndex), sign, rbd::Jacobian(mbs[rIndex], bName), point);
+        return contacts.back().jac.jointsPath().back();
       }
+      return mbs[rIndex].bodyIndexByName(bName);
     };
-    addContact(cC.cId.r1Index, cC.cId.r1BodyName, 1., cC.X_b1_cf);
-    addContact(cC.cId.r2Index, cC.cId.r2BodyName, -1., cC.X_b1_cf * cC.X_b1_b2.inv());
+    int r1Index = cC.cId.r1Index;
+    int b1Index = addContact(r1Index, cC.cId.r1BodyName, 1., cC.X_b1_cf);
+    int r2Index = cC.cId.r2Index;
+    int b2Index = addContact(r2Index, cC.cId.r2BodyName, -1., cC.X_b1_cf * cC.X_b1_b2.inv());
 
-    int b1Index = mbs[cC.cId.r1Index].bodyIndexByName(cC.cId.r1BodyName);
-    int b2Index = mbs[cC.cId.r2Index].bodyIndexByName(cC.cId.r2BodyName);
-    cont_.emplace_back(std::move(contacts), dof, b1Index, b2Index, cC.X_b1_b2, cC.X_b1_cf, cC.cId);
+    cont_.emplace_back(std::move(contacts), dof, r1Index, r2Index, b1Index, b2Index, cC.X_b1_b2, cC.X_b1_cf, cC.cId);
   }
   updateNrEq();
 
@@ -212,6 +235,8 @@ void ContactAccConstr::update(const std::vector<rbd::MultiBody> & mbs,
     ContactData & cd = cont_[i];
     int rows = int(cd.dof.rows());
 
+    cd.update(mbcs);
+
     for(std::size_t j = 0; j < cd.contacts.size(); ++j)
     {
       ContactSideData & csd = cd.contacts[j];
@@ -262,6 +287,8 @@ void ContactSpeedConstr::update(const std::vector<rbd::MultiBody> & mbs,
   {
     ContactData & cd = cont_[i];
     int rows = int(cd.dof.rows());
+
+    cd.update(mbcs);
 
     for(std::size_t j = 0; j < cd.contacts.size(); ++j)
     {
@@ -315,6 +342,8 @@ void ContactPosConstr::update(const std::vector<rbd::MultiBody> & mbs,
   {
     ContactData & cd = cont_[i];
     int rows = int(cd.dof.rows());
+
+    cd.update(mbcs);
 
     for(std::size_t j = 0; j < cd.contacts.size(); ++j)
     {

--- a/src/Tasks/QPContactConstr.h
+++ b/src/Tasks/QPContactConstr.h
@@ -131,17 +131,38 @@ protected:
   {
     ContactData(std::vector<ContactSideData> csds,
                 const Eigen::MatrixXd & d,
+                int r1,
+                int r2,
                 int b1,
                 int b2,
                 const sva::PTransformd & X_bb,
                 const sva::PTransformd & X_bcf,
                 const ContactId & cId)
-    : contacts(std::move(csds)), dof(d), b1Index(b1), b2Index(b2), X_b1_b2(X_bb), X_b1_cf(X_bcf), contactId(cId)
+    : contacts(std::move(csds)), dof(d), r1Index(r1), r2Index(r2), b1Index(b1), b2Index(b2), X_b1_b2(X_bb),
+      X_b1_cf(X_bcf), contactId(cId)
     {
+      revDof = Eigen::Matrix6d::Zero();
+      // Find which dofs are selected and reverse that selection
+      for(int j = 0; j < 6; ++j)
+      {
+        bool dof_j_active = false;
+        for(int r = 0; r < dof.rows(); ++r)
+        {
+          dof_j_active = dof_j_active || dof(r, j) == 1;
+        }
+        if(!dof_j_active)
+        {
+          revDof(j, j) = 1;
+        }
+      }
     }
+
+    void update(const std::vector<rbd::MultiBodyConfig> & mbcs);
 
     std::vector<ContactSideData> contacts;
     Eigen::MatrixXd dof;
+    Eigen::MatrixXd revDof;
+    int r1Index, r2Index;
     int b1Index, b2Index;
     sva::PTransformd X_b1_b2;
     sva::PTransformd X_b1_cf;


### PR DESCRIPTION
When a contact between two active robots (or when the only active robot is the second robot in a contact) is added, the X_b1_b2 transformation is encoded into the transformation for b2 to the contact frame (X_b2_cf).

However, when we allow the frames to move relatively to each other (using a DoF matrix), we implicitly allow this X_b1_b2 transformation to change over time.

We should account for the change in the X_b1_b2 transformation that is allowed by this DoF. Otherwise, the DoF allows seemingly arbitrary motions of the two contact frames.