### PR TITLE
Extending the PostureTask for reference velocities and accelerations

### DIFF
--- a/src/Tasks.cpp
+++ b/src/Tasks.cpp
@@ -821,6 +821,26 @@ const std::vector<std::vector<double>> PostureTask::posture() const
   return q_;
 }
 
+void PostureTask::refVel(std::vector<std::vector<double>> qd)
+{
+  qd_ = qd;
+}
+
+const std::vector<std::vector<double>> PostureTask::refVel() const
+{
+  return qd_;
+}
+
+void PostureTask::refAccel(std::vector<std::vector<double>> qdd)
+{
+  qdd_ = qdd;
+}
+
+const std::vector<std::vector<double>> PostureTask::refAccel() const
+{
+  return qdd_;
+}
+
 void PostureTask::update(const rbd::MultiBody & mb, const rbd::MultiBodyConfig & mbc)
 {
   using namespace Eigen;

--- a/src/Tasks/QPTasks.h
+++ b/src/Tasks/QPTasks.h
@@ -489,6 +489,26 @@ public:
     return pt_.posture();
   }
 
+  void refVel(std::vector<std::vector<double>> qd)
+  {
+    pt_.refVel(qd);
+  }
+
+  const std::vector<std::vector<double>> refVel() const
+  {
+    return pt_.refVel();
+  }
+
+  void refAccel(std::vector<std::vector<double>> qdd)
+  {
+    pt_.refAccel(qdd);
+  }
+
+  const std::vector<std::vector<double>> refAccel() const
+  {
+    return pt_.refAccel();
+  }
+
   double stiffness() const
   {
     return stiffness_;

--- a/src/Tasks/Tasks.h
+++ b/src/Tasks/Tasks.h
@@ -377,6 +377,10 @@ public:
 
   void posture(std::vector<std::vector<double>> q);
   const std::vector<std::vector<double>> posture() const;
+  void refVel(std::vector<std::vector<double>> qd);
+  const std::vector<std::vector<double>> refVel() const;
+  void refAccel(std::vector<std::vector<double>> qdd);
+  const std::vector<std::vector<double>> refAccel() const;
 
   void update(const rbd::MultiBody & mb, const rbd::MultiBodyConfig & mbc);
   void updateDot(const rbd::MultiBody & mb, const rbd::MultiBodyConfig & mbc);
@@ -387,6 +391,8 @@ public:
 
 private:
   std::vector<std::vector<double>> q_;
+  std::vector<std::vector<double>> qd_;
+  std::vector<std::vector<double>> qdd_;
 
   Eigen::VectorXd eval_;
   Eigen::MatrixXd jacMat_;


### PR DESCRIPTION
Hi @gergondet
so far I added new methods refVel() and refAccel().
It is, however, unclear to me where and how to incorporate the reference velocities and accelerations into the control law: in Tasks.cpp or in QPTasks.cpp ?
It seems that `Tasks.cpp` is not aware of stiffness and damping values.
thanks for your advice
Niels
