### PR TITLE
introduce joint jerk bounds

### DIFF
--- a/src/QPConstr.cpp
+++ b/src/QPConstr.cpp
@@ -33,7 +33,7 @@ namespace qp
  */
 
 JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs, int robotIndex, QBound bound, double step)
-: JointLimitsConstr(mbs, robotIndex, bound, {}, step)
+: JointLimitsConstr(mbs, robotIndex, bound, {}, {}, step)
 {
 }
 
@@ -42,9 +42,19 @@ JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
                                      QBound bound,
                                      const AlphaDBound & aDBound,
                                      double step)
+: JointLimitsConstr(mbs, robotIndex, bound, aDBound, {}, step)
+{
+}
+
+JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
+                                     int robotIndex,
+                                     QBound bound,
+                                     const AlphaDBound & aDBound,
+                                     const AlphaDDBound & aDDBound,
+                                     double step)
 : robotIndex_(robotIndex), alphaDBegin_(-1),
   alphaDOffset_(mbs[robotIndex].joint(0).dof() > 1 ? mbs[robotIndex].joint(0).dof() : 0), step_(step), qMin_(), qMax_(),
-  qVec_(), alphaVec_(), lower_(), upper_(), alphaDLower_(), alphaDUpper_()
+  qVec_(), alphaVec_(), lower_(), upper_(), alphaDLower_(), alphaDUpper_(), alphaDDLower_(), alphaDDUpper_()
 {
   assert(std::size_t(robotIndex_) < mbs.size() && robotIndex_ >= 0);
 
@@ -61,6 +71,10 @@ JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
   alphaDUpper_.resize(mb.nrDof());
   alphaDLower_.setConstant(-std::numeric_limits<double>::infinity());
   alphaDUpper_.setConstant(std::numeric_limits<double>::infinity());
+  alphaDDLower_.resize(mb.nrDof());
+  alphaDDUpper_.resize(mb.nrDof());
+  alphaDDLower_.setConstant(-std::numeric_limits<double>::infinity());
+  alphaDDUpper_.setConstant(std::numeric_limits<double>::infinity());
 
   // if first joint is not managed remove it
   if(alphaDOffset_ != 0)
@@ -77,6 +91,9 @@ JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
 
   rbd::paramToVector(aDBound.lAlphaDBound, alphaDLower_);
   rbd::paramToVector(aDBound.uAlphaDBound, alphaDUpper_);
+
+  rbd::paramToVector(aDDBound.lAlphaDDBound, alphaDDLower_);
+  rbd::paramToVector(aDDBound.uAlphaDDBound, alphaDDUpper_);
 }
 
 void JointLimitsConstr::updateNrVars(const std::vector<rbd::MultiBody> & /* mbs */, const SolverData & data)
@@ -105,6 +122,8 @@ void JointLimitsConstr::update(const std::vector<rbd::MultiBody> & /* mbs */,
 
   lower_ = lower_.cwiseMax(alphaDLower_);
   upper_ = upper_.cwiseMin(alphaDUpper_);
+  lower_ = lower_.cwiseMax((alphaDDLower_ * step_));
+  upper_ = upper_.cwiseMin((alphaDDUpper_ * step_));
 }
 
 std::string JointLimitsConstr::nameBound() const
@@ -145,7 +164,7 @@ DamperJointLimitsConstr::DamperJointLimitsConstr(const std::vector<rbd::MultiBod
                                                  double securityPercent,
                                                  double damperOffset,
                                                  double step)
-: DamperJointLimitsConstr(mbs, robotIndex, qBound, aBound, {}, interPercent, securityPercent, damperOffset, step)
+: DamperJointLimitsConstr(mbs, robotIndex, qBound, aBound, {}, {}, interPercent, securityPercent, damperOffset, step)
 {
 }
 
@@ -158,8 +177,32 @@ DamperJointLimitsConstr::DamperJointLimitsConstr(const std::vector<rbd::MultiBod
                                                  double securityPercent,
                                                  double damperOffset,
                                                  double step)
+: DamperJointLimitsConstr(mbs,
+                          robotIndex,
+                          qBound,
+                          aBound,
+                          aDBound,
+                          {},
+                          interPercent,
+                          securityPercent,
+                          damperOffset,
+                          step)
+{
+}
+
+DamperJointLimitsConstr::DamperJointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
+                                                 int robotIndex,
+                                                 const QBound & qBound,
+                                                 const AlphaBound & aBound,
+                                                 const AlphaDBound & aDBound,
+                                                 const AlphaDDBound & aDDBound,
+                                                 double interPercent,
+                                                 double securityPercent,
+                                                 double damperOffset,
+                                                 double step)
 : robotIndex_(robotIndex), alphaDBegin_(-1), data_(), lower_(mbs[robotIndex].nrDof()), upper_(mbs[robotIndex].nrDof()),
-  alphaDLower_(mbs[robotIndex].nrDof()), alphaDUpper_(mbs[robotIndex].nrDof()), step_(step), damperOff_(damperOffset)
+  alphaDLower_(mbs[robotIndex].nrDof()), alphaDUpper_(mbs[robotIndex].nrDof()), alphaDDLower_(mbs[robotIndex].nrDof()),
+  alphaDDUpper_(mbs[robotIndex].nrDof()), step_(step), damperOff_(damperOffset)
 {
   assert(std::size_t(robotIndex_) < mbs.size() && robotIndex_ >= 0);
 
@@ -179,8 +222,12 @@ DamperJointLimitsConstr::DamperJointLimitsConstr(const std::vector<rbd::MultiBod
   rbd::paramToVector(aBound.uAlphaBound, upper_);
   alphaDLower_.setConstant(-std::numeric_limits<double>::infinity());
   alphaDUpper_.setConstant(std::numeric_limits<double>::infinity());
+  alphaDDLower_.setConstant(-std::numeric_limits<double>::infinity());
+  alphaDDUpper_.setConstant(std::numeric_limits<double>::infinity());
   rbd::paramToVector(aDBound.lAlphaDBound, alphaDLower_);
   rbd::paramToVector(aDBound.uAlphaDBound, alphaDUpper_);
+  rbd::paramToVector(aDDBound.lAlphaDDBound, alphaDDLower_);
+  rbd::paramToVector(aDDBound.uAlphaDDBound, alphaDDUpper_);
 }
 
 void DamperJointLimitsConstr::updateNrVars(const std::vector<rbd::MultiBody> & /* mbs */, const SolverData & data)
@@ -238,6 +285,8 @@ void DamperJointLimitsConstr::update(const std::vector<rbd::MultiBody> & /* mbs 
   }
   lower_ = lower_.cwiseMax(alphaDLower_);
   upper_ = upper_.cwiseMin(alphaDUpper_);
+  lower_ = lower_.cwiseMax((alphaDDLower_ * step_));
+  upper_ = upper_.cwiseMin((alphaDDUpper_ * step_));
 }
 
 std::string DamperJointLimitsConstr::nameBound() const

--- a/src/QPConstr.cpp
+++ b/src/QPConstr.cpp
@@ -55,7 +55,7 @@ JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
 : robotIndex_(robotIndex), alphaDBegin_(-1),
   alphaDOffset_(mbs[robotIndex].joint(0).dof() > 1 ? mbs[robotIndex].joint(0).dof() : 0), step_(step), qMin_(), qMax_(),
   qVec_(), alphaVec_(), lower_(), upper_(), alphaDLower_(), alphaDUpper_(), alphaDDLower_(), alphaDDUpper_(),
-  curAlphaD_()
+  prevAlphaD_()
 {
   assert(std::size_t(robotIndex_) < mbs.size() && robotIndex_ >= 0);
 
@@ -76,7 +76,8 @@ JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
   alphaDDUpper_.resize(mb.nrDof());
   alphaDDLower_.setConstant(-std::numeric_limits<double>::infinity());
   alphaDDUpper_.setConstant(std::numeric_limits<double>::infinity());
-  curAlphaD_.resize(mb.nrDof());
+  prevAlphaD_.resize(mb.nrDof());
+  prevAlphaD_.setZero();
 
   // if first joint is not managed remove it
   if(alphaDOffset_ != 0)
@@ -96,6 +97,8 @@ JointLimitsConstr::JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
 
   rbd::paramToVector(aDDBound.lAlphaDDBound, alphaDDLower_);
   rbd::paramToVector(aDDBound.uAlphaDDBound, alphaDDUpper_);
+  alphaDDLower_ *= step_;
+  alphaDDUpper_ *= step_;
 }
 
 void JointLimitsConstr::updateNrVars(const std::vector<rbd::MultiBody> & /* mbs */, const SolverData & data)
@@ -115,6 +118,7 @@ void JointLimitsConstr::update(const std::vector<rbd::MultiBody> & /* mbs */,
 
   rbd::paramToVector(mbc.q, qVec_);
   rbd::paramToVector(mbc.alpha, alphaVec_);
+  rbd::paramToVector(mbc.alphaD, prevAlphaD_);
 
   lower_.noalias() = qMin_ - qVec_.tail(vars) - alphaVec_.tail(vars) * step_;
   lower_ /= dts;
@@ -122,10 +126,8 @@ void JointLimitsConstr::update(const std::vector<rbd::MultiBody> & /* mbs */,
   upper_.noalias() = qMax_ - qVec_.tail(vars) - alphaVec_.tail(vars) * step_;
   upper_ /= dts;
 
-  lower_ = lower_.cwiseMax(alphaDLower_);
-  upper_ = upper_.cwiseMin(alphaDUpper_);
-  lower_ = lower_.cwiseMax((alphaDDLower_ * step_) + curAlphaD_);
-  upper_ = upper_.cwiseMin((alphaDDUpper_ * step_) + curAlphaD_);
+  lower_ = lower_.cwiseMax(alphaDLower_).cwiseMax(alphaDDLower_ + prevAlphaD_);
+  upper_ = upper_.cwiseMin(alphaDUpper_).cwiseMin(alphaDDUpper_ + prevAlphaD_);
 }
 
 std::string JointLimitsConstr::nameBound() const
@@ -204,7 +206,7 @@ DamperJointLimitsConstr::DamperJointLimitsConstr(const std::vector<rbd::MultiBod
                                                  double step)
 : robotIndex_(robotIndex), alphaDBegin_(-1), data_(), lower_(mbs[robotIndex].nrDof()), upper_(mbs[robotIndex].nrDof()),
   alphaDLower_(mbs[robotIndex].nrDof()), alphaDUpper_(mbs[robotIndex].nrDof()), alphaDDLower_(mbs[robotIndex].nrDof()),
-  alphaDDUpper_(mbs[robotIndex].nrDof()), curAlphaD_(mbs[robotIndex].nrDof()), step_(step), damperOff_(damperOffset)
+  alphaDDUpper_(mbs[robotIndex].nrDof()), prevAlphaD_(mbs[robotIndex].nrDof()), step_(step), damperOff_(damperOffset)
 {
   assert(std::size_t(robotIndex_) < mbs.size() && robotIndex_ >= 0);
 
@@ -230,6 +232,9 @@ DamperJointLimitsConstr::DamperJointLimitsConstr(const std::vector<rbd::MultiBod
   rbd::paramToVector(aDBound.uAlphaDBound, alphaDUpper_);
   rbd::paramToVector(aDDBound.lAlphaDDBound, alphaDDLower_);
   rbd::paramToVector(aDDBound.uAlphaDDBound, alphaDDUpper_);
+  alphaDDLower_ *= step_;
+  alphaDDUpper_ *= step_;
+  prevAlphaD_.setZero();
 }
 
 void DamperJointLimitsConstr::updateNrVars(const std::vector<rbd::MultiBody> & /* mbs */, const SolverData & data)
@@ -242,6 +247,7 @@ void DamperJointLimitsConstr::update(const std::vector<rbd::MultiBody> & /* mbs 
                                      const SolverData & /* data */)
 {
   const rbd::MultiBodyConfig & mbc = mbcs[robotIndex_];
+  rbd::paramToVector(mbc.alphaD, prevAlphaD_);
 
   for(DampData & d : data_)
   {
@@ -285,10 +291,8 @@ void DamperJointLimitsConstr::update(const std::vector<rbd::MultiBody> & /* mbs 
       d.state = DampData::Free;
     }
   }
-  lower_ = lower_.cwiseMax(alphaDLower_);
-  upper_ = upper_.cwiseMin(alphaDUpper_);
-  lower_ = lower_.cwiseMax((alphaDDLower_ * step_) + curAlphaD_);
-  upper_ = upper_.cwiseMin((alphaDDUpper_ * step_) + curAlphaD_);
+  lower_ = lower_.cwiseMax(alphaDLower_).cwiseMax(alphaDDLower_ + prevAlphaD_);
+  upper_ = upper_.cwiseMin(alphaDUpper_).cwiseMin(alphaDDUpper_ + prevAlphaD_);
 }
 
 std::string DamperJointLimitsConstr::nameBound() const

--- a/src/Tasks/Bounds.h
+++ b/src/Tasks/Bounds.h
@@ -70,6 +70,24 @@ struct AlphaDBound
 };
 
 /**
+ * General jerk vector bounds
+ * \f$ \underline{\ddot{\alpha}} \f$ and \f$ \overline{\ddot{\alpha}} \f$.
+ */
+struct AlphaDDBound
+{
+  AlphaDDBound() {}
+  AlphaDDBound(std::vector<std::vector<double>> lADDB, std::vector<std::vector<double>> uADDB)
+  : lAlphaDDBound(std::move(lADDB)), uAlphaDDBound(std::move(uADDB))
+  {
+  }
+
+  /// \f$ \underline{\ddot{\alpha}} \f$
+  std::vector<std::vector<double>> lAlphaDDBound;
+  /// \f$ \overline{\ddot{\alpha}} \f$
+  std::vector<std::vector<double>> uAlphaDDBound;
+};
+
+/**
  * General force vector bounds
  * \f$ \underline{\tau} \f$ and \f$ \overline{\tau} \f$.
  */

--- a/src/Tasks/QPConstr.h
+++ b/src/Tasks/QPConstr.h
@@ -35,6 +35,7 @@ namespace tasks
 struct QBound;
 struct AlphaBound;
 struct AlphaDBound;
+struct AlphaDDBound;
 
 namespace qp
 {
@@ -76,6 +77,21 @@ public:
                     const AlphaDBound & aDBound,
                     double step);
 
+  /**
+   * @param mbs Multi-robot system.
+   * @param robotIndex Constrained robot Index in mbs.
+   * @param bound Articular position bounds.
+   * @param aDBound Articular acceleration bounds.
+   * @param aDDBound Articular jerk bounds.
+   * @param step Time step in second.
+   */
+  JointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
+                    int robotIndex,
+                    QBound bound,
+                    const AlphaDBound & aDBound,
+                    const AlphaDDBound & aDDBound,
+                    double step);
+
   // Constraint
   virtual void updateNrVars(const std::vector<rbd::MultiBody> & mbs, const SolverData & data) override;
 
@@ -99,6 +115,7 @@ private:
   Eigen::VectorXd qVec_, alphaVec_;
   Eigen::VectorXd lower_, upper_;
   Eigen::VectorXd alphaDLower_, alphaDUpper_;
+  Eigen::VectorXd alphaDDLower_, alphaDDUpper_;
 };
 
 /**
@@ -151,7 +168,6 @@ public:
                           double securityPercent,
                           double damperOffset,
                           double step);
-
   /**
    * @param mbs Multi-robot system.
    * @param robotIndex Constrained robot Index in mbs.
@@ -168,6 +184,29 @@ public:
                           const QBound & qBound,
                           const AlphaBound & aBound,
                           const AlphaDBound & aDBound,
+                          double interPercent,
+                          double securityPercent,
+                          double damperOffset,
+                          double step);
+
+  /**
+   * @param mbs Multi-robot system.
+   * @param robotIndex Constrained robot Index in mbs.
+   * @param qBound Articular position bounds.
+   * @param aBound Articular velocity bounds.
+   * @param aDBound Articular acceleration bounds.
+   * @param aDDBound Articular jerk bounds.
+   * @param interPercent \f$ interPercent (\overline{q} - \underline{q}) \f$
+   * @param securityPercent \f$ securityPercent (\overline{q} - \underline{q}) \f$
+   * @param damperOffset \f$ \xi_{\text{off}} \f$
+   * @param step Time step in second.
+   */
+  DamperJointLimitsConstr(const std::vector<rbd::MultiBody> & mbs,
+                          int robotIndex,
+                          const QBound & qBound,
+                          const AlphaBound & aBound,
+                          const AlphaDBound & aDBound,
+                          const AlphaDDBound & aDDBound,
                           double interPercent,
                           double securityPercent,
                           double damperOffset,
@@ -224,6 +263,7 @@ private:
 
   Eigen::VectorXd lower_, upper_;
   Eigen::VectorXd alphaDLower_, alphaDUpper_;
+  Eigen::VectorXd alphaDDLower_, alphaDDUpper_;
   double step_;
   double damperOff_;
 };

--- a/src/Tasks/QPConstr.h
+++ b/src/Tasks/QPConstr.h
@@ -116,6 +116,7 @@ private:
   Eigen::VectorXd lower_, upper_;
   Eigen::VectorXd alphaDLower_, alphaDUpper_;
   Eigen::VectorXd alphaDDLower_, alphaDDUpper_;
+  Eigen::VectorXd curAlphaD_;
 };
 
 /**
@@ -264,6 +265,7 @@ private:
   Eigen::VectorXd lower_, upper_;
   Eigen::VectorXd alphaDLower_, alphaDUpper_;
   Eigen::VectorXd alphaDDLower_, alphaDDUpper_;
+  Eigen::VectorXd curAlphaD_;
   double step_;
   double damperOff_;
 };

--- a/src/Tasks/QPConstr.h
+++ b/src/Tasks/QPConstr.h
@@ -116,7 +116,7 @@ private:
   Eigen::VectorXd lower_, upper_;
   Eigen::VectorXd alphaDLower_, alphaDUpper_;
   Eigen::VectorXd alphaDDLower_, alphaDDUpper_;
-  Eigen::VectorXd curAlphaD_;
+  Eigen::VectorXd prevAlphaD_;
 };
 
 /**
@@ -265,7 +265,7 @@ private:
   Eigen::VectorXd lower_, upper_;
   Eigen::VectorXd alphaDLower_, alphaDUpper_;
   Eigen::VectorXd alphaDDLower_, alphaDDUpper_;
-  Eigen::VectorXd curAlphaD_;
+  Eigen::VectorXd prevAlphaD_;
   double step_;
   double damperOff_;
 };

--- a/tests/QPSolverTest.cpp
+++ b/tests/QPSolverTest.cpp
@@ -464,8 +464,10 @@ BOOST_AUTO_TEST_CASE(QPJointLimitsTest)
   std::vector<std::vector<double>> uBound = {{}, {cst::pi<double>() / 4.}, {inf}, {inf}};
   std::vector<std::vector<double>> lDDBound = {{}, {-inf}, {-inf}, {-inf}};
   std::vector<std::vector<double>> uDDBound = {{}, {inf}, {inf}, {inf}};
+  std::vector<std::vector<double>> lDDDBound = {{}, {-inf}, {-inf}, {-inf}};
+  std::vector<std::vector<double>> uDDDBound = {{}, {inf}, {inf}, {inf}};
 
-  qp::JointLimitsConstr jointConstr(mbs, 0, {lBound, uBound}, {lDDBound, uDDBound}, 0.001);
+  qp::JointLimitsConstr jointConstr(mbs, 0, {lBound, uBound}, {lDDBound, uDDBound}, {lDDDBound, uDDDBound}, 0.001);
 
   // Test add*Constraint
   solver.addBoundConstraint(&jointConstr);
@@ -545,9 +547,11 @@ BOOST_AUTO_TEST_CASE(QPDamperJointLimitsTest)
   std::vector<std::vector<double>> uVel = {{}, {inf}, {inf}, {inf}};
   std::vector<std::vector<double>> lAcc = {{}, {-inf}, {-inf}, {-inf}};
   std::vector<std::vector<double>> uAcc = {{}, {inf}, {inf}, {inf}};
+  std::vector<std::vector<double>> lJer = {{}, {-inf}, {-inf}, {-inf}};
+  std::vector<std::vector<double>> uJer = {{}, {inf}, {inf}, {inf}};
 
-  qp::DamperJointLimitsConstr dampJointConstr(mbs, 0, {lBound, uBound}, {lVel, uVel}, {lAcc, uAcc}, 0.125, 0.025, 1.,
-                                              0.001);
+  qp::DamperJointLimitsConstr dampJointConstr(mbs, 0, {lBound, uBound}, {lVel, uVel}, {lAcc, uAcc}, {lJer, uJer}, 0.125,
+                                              0.025, 1., 0.001);
 
   // Test add*Constraint
   dampJointConstr.addToSolver(solver);


### PR DESCRIPTION
Analogously to the existing joint acceleration bounds, this PR introduces joint jerk bounds.
For some robots these limits are defined by the manufacturer, see for example the panda manipulator.