### PR TITLE
[CI] fix macos CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
           apt: cython cython3 python-pytest python3-pytest python-numpy python3-numpy python-coverage python3-coverage python-setuptools python3-setuptools libeigen3-dev doxygen doxygen-latex libboost-all-dev libtinyxml2-dev libyaml-cpp-dev
         macos: |
           cask: gfortran
-          brew: eigen boost tinyxml2 yaml-cpp
-          pip: Cython coverage pytest numpy
+          brew: eigen boost tinyxml2 yaml-cpp pipx
+          pipx: Cython coverage pytest numpy
         windows: |
           pip: Cython coverage pytest numpy
           github:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ include(cmake/msvc-specific.cmake)
 
 project(Tasks CXX)
 
-if(UNIX AND NOT EMSCRIPTEN AND NOT (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm"))
+if(UNIX
+   AND NOT EMSCRIPTEN
+   AND NOT (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+)
   include(CheckCXXSourceCompiles)
   check_cxx_compiler_flag("-msse2" SSE2_SUPPORTED)
   if(SSE2_SUPPORTED)


### PR DESCRIPTION
```
× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-brew-packaged Python package,
    create a virtual environment using python -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.
    
    If you wish to install a non-brew packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
[Python Documentation](https://packaging.python.org/en/latest/specifications/externally-managed-environments/#externally-managed-environments)
[PEP 668](https://peps.python.org/pep-0668/)
