### PR TITLE
Add the possibility to compensate an external disturbance torques

### DIFF
--- a/src/QPMotionConstr.cpp
+++ b/src/QPMotionConstr.cpp
@@ -109,24 +109,12 @@ MotionConstrCommon::ContactData::ContactData(const rbd::MultiBody & mb,
   }
 }
 
-MotionConstrCommon::MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs, int robotIndex)
-: robotIndex_(robotIndex), alphaDBegin_(-1), nrDof_(mbs[robotIndex_].nrDof()), lambdaBegin_(-1), fd_(mbs[robotIndex_]),
-  fullJacLambda_(), jacTrans_(6, nrDof_), jacLambda_(), cont_(), curTorque_(nrDof_), useExternalTorque_(false),
-  extTorque_(curTorque_), A_(), AL_(nrDof_), AU_(nrDof_)
-{
-  // We set the extTorque_ reference to curTorque_ as it needs to be initialized in the struct but we are not going to
-  // use it
-  assert(std::size_t(robotIndex_) < mbs.size() && robotIndex_ >= 0);
-  // This is technically incorrect but practically not a huge deal, see #66
-  curTorque_.setZero();
-}
-
 MotionConstrCommon::MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs,
                                        int robotIndex,
-                                       const Eigen::VectorXd & externalTorque)
+                                       std::optional<Eigen::VectorXd> externalTorque)
 : robotIndex_(robotIndex), alphaDBegin_(-1), nrDof_(mbs[robotIndex_].nrDof()), lambdaBegin_(-1), fd_(mbs[robotIndex_]),
-  fullJacLambda_(), jacTrans_(6, nrDof_), jacLambda_(), cont_(), curTorque_(nrDof_), useExternalTorque_(true),
-  extTorque_(externalTorque), A_(), AL_(nrDof_), AU_(nrDof_)
+  fullJacLambda_(), jacTrans_(6, nrDof_), jacLambda_(), cont_(), curTorque_(nrDof_), extTorque_(externalTorque), A_(),
+  AL_(nrDof_), AU_(nrDof_)
 {
   assert(std::size_t(robotIndex_) < mbs.size() && robotIndex_ >= 0);
   // This is technically incorrect but practically not a huge deal, see #66
@@ -137,7 +125,7 @@ void MotionConstrCommon::computeTorque(const Eigen::VectorXd & alphaD, const Eig
 {
   curTorque_ = fd_.H() * alphaD.segment(alphaDBegin_, nrDof_);
   curTorque_ += fd_.C();
-  if(useExternalTorque_) { curTorque_ -= extTorque_; }
+  if(extTorque_) { curTorque_ -= extTorque_.value(); }
   curTorque_ += A_.block(0, lambdaBegin_, nrDof_, A_.cols() - lambdaBegin_) * lambda;
 }
 
@@ -236,10 +224,10 @@ void MotionConstrCommon::computeMatrix(const std::vector<rbd::MultiBody> & mbs,
   // BEq = -C
   AL_ = -fd_.C();
   AU_ = -fd_.C();
-  if(useExternalTorque_)
+  if(extTorque_)
   {
-    AL_ += extTorque_;
-    AU_ += extTorque_;
+    AL_ += extTorque_.value();
+    AU_ += extTorque_.value();
   }
 }
 
@@ -274,19 +262,21 @@ std::string MotionConstrCommon::descGenInEq(const std::vector<rbd::MultiBody> & 
   return std::string("Joint: ") + mbs[robotIndex_].joint(jIndex).name();
 }
 
+void MotionConstrCommon::setExternalTorques(const Eigen::VectorXd & torques)
+{
+  if(!extTorque_) { extTorque_.emplace(torques.size()); }
+  else if(extTorque_->size() == torques.size()) { extTorque_->resize(torques.size()); }
+  extTorque_->noalias() = torques;
+}
+
 /**
  *															MotionConstr
  */
 
-MotionConstr::MotionConstr(const std::vector<rbd::MultiBody> & mbs, int robotIndex, const TorqueBound & tb)
-: MotionConstr(mbs, robotIndex, tb, {}, 0.001)
-{
-}
-
 MotionConstr::MotionConstr(const std::vector<rbd::MultiBody> & mbs,
                            int robotIndex,
                            const TorqueBound & tb,
-                           const Eigen::VectorXd & externalTorque)
+                           std::optional<Eigen::VectorXd> externalTorque)
 : MotionConstr(mbs, robotIndex, tb, {}, 0.001, externalTorque)
 {
 }
@@ -295,26 +285,8 @@ MotionConstr::MotionConstr(const std::vector<rbd::MultiBody> & mbs,
                            int robotIndex,
                            const TorqueBound & tb,
                            const TorqueDBound & tdb,
-                           double dt)
-: MotionConstrCommon(mbs, robotIndex), torqueL_(mbs[robotIndex].nrDof()), torqueU_(mbs[robotIndex].nrDof()),
-  torqueDtL_(mbs[robotIndex].nrDof()), torqueDtU_(mbs[robotIndex].nrDof()), tmpL_(nrDof_), tmpU_(nrDof_)
-{
-  rbd::paramToVector(tb.lTorqueBound, torqueL_);
-  rbd::paramToVector(tb.uTorqueBound, torqueU_);
-  torqueDtL_.setConstant(-std::numeric_limits<double>::infinity());
-  torqueDtU_.setConstant(std::numeric_limits<double>::infinity());
-  rbd::paramToVector(tdb.lTorqueDBound, torqueDtL_);
-  rbd::paramToVector(tdb.uTorqueDBound, torqueDtU_);
-  torqueDtL_ *= dt;
-  torqueDtU_ *= dt;
-}
-
-MotionConstr::MotionConstr(const std::vector<rbd::MultiBody> & mbs,
-                           int robotIndex,
-                           const TorqueBound & tb,
-                           const TorqueDBound & tdb,
                            double dt,
-                           const Eigen::VectorXd & externalTorque)
+                           std::optional<Eigen::VectorXd> externalTorque)
 : MotionConstrCommon(mbs, robotIndex, externalTorque), torqueL_(mbs[robotIndex].nrDof()),
   torqueU_(mbs[robotIndex].nrDof()), torqueDtL_(mbs[robotIndex].nrDof()), torqueDtU_(mbs[robotIndex].nrDof()),
   tmpL_(nrDof_), tmpU_(nrDof_)
@@ -365,16 +337,8 @@ const rbd::ForwardDynamics MotionConstr::fd() const
 MotionSpringConstr::MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
                                        int robotIndex,
                                        const TorqueBound & tb,
-                                       const std::vector<SpringJoint> & springs)
-: MotionSpringConstr(mbs, robotIndex, tb, {}, 0.001, springs)
-{
-}
-
-MotionSpringConstr::MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
-                                       int robotIndex,
-                                       const TorqueBound & tb,
                                        const std::vector<SpringJoint> & springs,
-                                       const Eigen::VectorXd & externalTorque)
+                                       std::optional<Eigen::VectorXd> externalTorque)
 : MotionSpringConstr(mbs, robotIndex, tb, {}, 0.001, springs, externalTorque)
 {
 }
@@ -384,25 +348,8 @@ MotionSpringConstr::MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
                                        const TorqueBound & tb,
                                        const TorqueDBound & tdb,
                                        double dt,
-                                       const std::vector<SpringJoint> & springs)
-: MotionConstr(mbs, robotIndex, tb, tdb, dt), springs_()
-{
-  const rbd::MultiBody & mb = mbs[robotIndex_];
-  for(const SpringJoint & sj : springs)
-  {
-    int index = mb.jointIndexByName(sj.jointName);
-    int posInDof = mb.jointPosInDof(index);
-    springs_.push_back({index, posInDof, sj.K, sj.C, sj.O});
-  }
-}
-
-MotionSpringConstr::MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
-                                       int robotIndex,
-                                       const TorqueBound & tb,
-                                       const TorqueDBound & tdb,
-                                       double dt,
                                        const std::vector<SpringJoint> & springs,
-                                       const Eigen::VectorXd & externalTorque)
+                                       std::optional<Eigen::VectorXd> externalTorque)
 : MotionConstr(mbs, robotIndex, tb, tdb, dt, externalTorque), springs_()
 {
   const rbd::MultiBody & mb = mbs[robotIndex_];

--- a/src/Tasks/QPMotionConstr.h
+++ b/src/Tasks/QPMotionConstr.h
@@ -66,6 +66,7 @@ class TASKS_DLLAPI MotionConstrCommon : public ConstraintFunction<GenInequality>
 {
 public:
   MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs, int robotIndex);
+  MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs, int robotIndex, const Eigen::VectorXd & externalTorque);
 
   void computeTorque(const Eigen::VectorXd & alphaD, const Eigen::VectorXd & lambda);
   const Eigen::VectorXd & torque() const;
@@ -114,6 +115,9 @@ protected:
 
   Eigen::VectorXd curTorque_;
 
+  bool useExternalTorque_;
+  const Eigen::VectorXd & extTorque_;
+
   Eigen::MatrixXd A_;
   Eigen::VectorXd AL_, AU_;
   size_t updateIter_ = 0;
@@ -123,12 +127,23 @@ class TASKS_DLLAPI MotionConstr : public MotionConstrCommon
 {
 public:
   MotionConstr(const std::vector<rbd::MultiBody> & mbs, int robotIndex, const TorqueBound & tb);
+  MotionConstr(const std::vector<rbd::MultiBody> & mbs,
+               int robotIndex,
+               const TorqueBound & tb,
+               const Eigen::VectorXd & externalTorque);
 
   MotionConstr(const std::vector<rbd::MultiBody> & mbs,
                int robotIndex,
                const TorqueBound & tb,
                const TorqueDBound & tdb,
                double dt);
+
+  MotionConstr(const std::vector<rbd::MultiBody> & mbs,
+               int robotIndex,
+               const TorqueBound & tb,
+               const TorqueDBound & tdb,
+               double dt,
+               const Eigen::VectorXd & externalTorque);
 
   // Constraint
   virtual void update(const std::vector<rbd::MultiBody> & mbs,
@@ -167,9 +182,23 @@ public:
   MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
                      int robotIndex,
                      const TorqueBound & tb,
+                     const std::vector<SpringJoint> & springs,
+                     const Eigen::VectorXd & externalTorque);
+
+  MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
+                     int robotIndex,
+                     const TorqueBound & tb,
                      const TorqueDBound & tdb,
                      double dt,
                      const std::vector<SpringJoint> & springs);
+
+  MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
+                     int robotIndex,
+                     const TorqueBound & tb,
+                     const TorqueDBound & tdb,
+                     double dt,
+                     const std::vector<SpringJoint> & springs,
+                     const Eigen::VectorXd & externalTorque);
 
   // Constraint
   virtual void update(const std::vector<rbd::MultiBody> & mbs,

--- a/src/Tasks/QPMotionConstr.h
+++ b/src/Tasks/QPMotionConstr.h
@@ -17,6 +17,7 @@
 
 // Tasks
 #include "QPSolver.h"
+#include <optional>
 
 namespace tasks
 {
@@ -65,8 +66,9 @@ private:
 class TASKS_DLLAPI MotionConstrCommon : public ConstraintFunction<GenInequality>
 {
 public:
-  MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs, int robotIndex);
-  MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs, int robotIndex, const Eigen::VectorXd & externalTorque);
+  MotionConstrCommon(const std::vector<rbd::MultiBody> & mbs,
+                     int robotIndex,
+                     std::optional<Eigen::VectorXd> externalTorque = std::nullopt);
 
   void computeTorque(const Eigen::VectorXd & alphaD, const Eigen::VectorXd & lambda);
   const Eigen::VectorXd & torque() const;
@@ -87,6 +89,9 @@ public:
   virtual const Eigen::MatrixXd & AGenInEq() const override;
   virtual const Eigen::VectorXd & LowerGenInEq() const override;
   virtual const Eigen::VectorXd & UpperGenInEq() const override;
+
+  // Update external torques value
+  void setExternalTorques(const Eigen::VectorXd & torques);
 
 protected:
   struct ContactData
@@ -115,8 +120,7 @@ protected:
 
   Eigen::VectorXd curTorque_;
 
-  bool useExternalTorque_;
-  const Eigen::VectorXd & extTorque_;
+  std::optional<Eigen::VectorXd> extTorque_;
 
   Eigen::MatrixXd A_;
   Eigen::VectorXd AL_, AU_;
@@ -126,24 +130,17 @@ protected:
 class TASKS_DLLAPI MotionConstr : public MotionConstrCommon
 {
 public:
-  MotionConstr(const std::vector<rbd::MultiBody> & mbs, int robotIndex, const TorqueBound & tb);
   MotionConstr(const std::vector<rbd::MultiBody> & mbs,
                int robotIndex,
                const TorqueBound & tb,
-               const Eigen::VectorXd & externalTorque);
-
-  MotionConstr(const std::vector<rbd::MultiBody> & mbs,
-               int robotIndex,
-               const TorqueBound & tb,
-               const TorqueDBound & tdb,
-               double dt);
+               std::optional<Eigen::VectorXd> externalTorque = std::nullopt);
 
   MotionConstr(const std::vector<rbd::MultiBody> & mbs,
                int robotIndex,
                const TorqueBound & tb,
                const TorqueDBound & tdb,
                double dt,
-               const Eigen::VectorXd & externalTorque);
+               std::optional<Eigen::VectorXd> externalTorque = std::nullopt);
 
   // Constraint
   virtual void update(const std::vector<rbd::MultiBody> & mbs,
@@ -177,20 +174,8 @@ public:
   MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
                      int robotIndex,
                      const TorqueBound & tb,
-                     const std::vector<SpringJoint> & springs);
-
-  MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
-                     int robotIndex,
-                     const TorqueBound & tb,
                      const std::vector<SpringJoint> & springs,
-                     const Eigen::VectorXd & externalTorque);
-
-  MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
-                     int robotIndex,
-                     const TorqueBound & tb,
-                     const TorqueDBound & tdb,
-                     double dt,
-                     const std::vector<SpringJoint> & springs);
+                     std::optional<Eigen::VectorXd> externalTorque = std::nullopt);
 
   MotionSpringConstr(const std::vector<rbd::MultiBody> & mbs,
                      int robotIndex,
@@ -198,7 +183,7 @@ public:
                      const TorqueDBound & tdb,
                      double dt,
                      const std::vector<SpringJoint> & springs,
-                     const Eigen::VectorXd & externalTorque);
+                     std::optional<Eigen::VectorXd> externalTorque = std::nullopt);
 
   // Constraint
   virtual void update(const std::vector<rbd::MultiBody> & mbs,


### PR DESCRIPTION
Add a copy of each constructors of `MotionConstrCommon`, `MotionConstr` and `MotionSpringConstr` that includes an additional reference to an `Eigen::VectorXd` that contains an estimation or the exact value of the external disturbance torques to be compensated for. `MotionConstrCommon` set a `bool` depending on which constructor is called to know if external torques should be accounted for.
- This is required to know if the reference is properly initialized. This value is later used in the `computeMatrix` and `computeTorque` function of `MotionConstrCommon` if external torques needs to be compensated.